### PR TITLE
Add defaults channel to environment configuration

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: bluesky-env
 channels:
+  - defaults
   - conda-forge
 dependencies:
   - python=3.12


### PR DESCRIPTION
## Summary
- add the defaults channel to `environment.yml` and ensure the channel order matches project guidance

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d190515b948327887fb8c727bf3c56