### PR TITLE
Refactor GUI sidebar into modular panels

### DIFF
--- a/tests/test_gui_disabled.py
+++ b/tests/test_gui_disabled.py
@@ -1,0 +1,13 @@
+from gui import app
+
+
+def test_sidebar_sections_collapsed():
+    labels = [label for label, _ in app.SIDEBAR_SECTIONS]
+    assert labels == [
+        'General config',
+        'Carbon policy',
+        'Electricity dispatch',
+        'Incentives / credits',
+        'Outputs',
+    ]
+    assert all(expanded is False for _, expanded in app.SIDEBAR_SECTIONS)


### PR DESCRIPTION
## Summary
- replace the Streamlit sidebar with modular panels for general config, carbon policy, dispatch, incentives, and outputs while keeping a shared run_config
- propagate module toggles, including the dispatch network flag, into the backend run inputs and expose module metadata in run results
- add regression tests covering the combined carbon/dispatch workflow and verify sidebar sections default to collapsed

## Testing
- pytest tests/test_gui_backend.py tests/test_gui_disabled.py

------
https://chatgpt.com/codex/tasks/task_e_68d2cfb7f11083279586d0df08a5dda3