### PR TITLE
Unify dependency manifests for CI and Streamlit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,62 +26,116 @@ jobs:
           path: |
             ./.pip
             ./.pytest_cache
-          key: ${{ runner.os }}-pip-py312-${{ hashFiles('requirements.txt', 'pyproject.toml') }}
+          key: ${{ runner.os }}-pip-py312-${{ hashFiles('requirements.txt', 'pyproject.toml', 'environment.yml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Detect Conda environment file
+        id: detect-env
+        shell: bash
+        run: |
+          if [[ -f environment.yml ]]; then
+            echo "use_conda=true" >> "$GITHUB_OUTPUT"
+            echo "env_file=environment.yml" >> "$GITHUB_OUTPUT"
+            echo "env_name=bluesky" >> "$GITHUB_OUTPUT"
+          elif [[ -f environment.yaml ]]; then
+            echo "use_conda=true" >> "$GITHUB_OUTPUT"
+            echo "env_file=environment.yaml" >> "$GITHUB_OUTPUT"
+            echo "env_name=bluesky" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_conda=false" >> "$GITHUB_OUTPUT"
+            echo "env_name=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Conda
+        if: steps.detect-env.outputs.use_conda == 'true'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: ${{ steps.detect-env.outputs.env_name }}
+          environment-file: ${{ steps.detect-env.outputs.env_file }}
+          auto-activate-base: false
+          python-version: 3.12
+
       - name: Set up Python
+        if: steps.detect-env.outputs.use_conda != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Verify dependency manifest
+        shell: python
         run: |
-          python - <<'PY'
-          import subprocess
           import sys
           from pathlib import Path
 
-          repo_files = subprocess.check_output(['git', 'ls-files'], text=True).splitlines()
-          candidates: list[Path] = []
-          for name in repo_files:
-              path = Path(name)
-              lower_name = path.name.lower()
-              if lower_name.startswith('requirements') and lower_name.endswith('.txt'):
-                  candidates.append(path)
-              elif lower_name in {'environment.yml', 'environment.yaml'}:
-                  candidates.append(path)
+          repo_root = Path('.')
+          requirements = {
+              path
+              for path in repo_root.rglob('requirements*.txt')
+              if path.name.lower().startswith('requirements')
+          }
+          expected = {Path('requirements.txt')}
 
-          allowed = {Path('requirements.txt')}
-          extras = [str(path) for path in candidates if path not in allowed]
+          missing = expected - requirements
+          extras = sorted(str(path) for path in requirements - expected)
 
-          if extras:
-              print('Unexpected dependency manifests detected:')
-              for path in extras:
-                  print(f'- {path}')
+          if missing or extras:
+              if missing:
+                  print('Missing expected requirements manifest:', ', '.join(str(path) for path in missing))
+              if extras:
+                  print('Unexpected requirements manifests detected:')
+                  for path in extras:
+                      print(f'- {path}')
               sys.exit(1)
-          PY
 
       - name: Install dependencies
+        shell: bash
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          if [[ "${{ steps.detect-env.outputs.use_conda }}" == "true" ]]; then
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} python -m pip install --upgrade pip
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} python -m pip install -r requirements.txt
+          else
+            python -m pip install --upgrade pip
+            python -m pip install -r requirements.txt
+          fi
 
       - name: Show Python diagnostics
+        shell: bash
         run: |
-          python --version
-          pip --version
+          if [[ "${{ steps.detect-env.outputs.use_conda }}" == "true" ]]; then
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} python --version
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} pip --version
+          else
+            python --version
+            pip --version
+          fi
 
       - name: Ruff lint
-        run: ruff check .
+        shell: bash
+        run: |
+          if [[ "${{ steps.detect-env.outputs.use_conda }}" == "true" ]]; then
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} ruff check .
+          else
+            ruff check .
+          fi
 
       - name: Mypy
-        run: mypy --config-file pyproject.toml
+        shell: bash
+        run: |
+          if [[ "${{ steps.detect-env.outputs.use_conda }}" == "true" ]]; then
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} mypy --config-file pyproject.toml
+          else
+            mypy --config-file pyproject.toml
+          fi
 
       - name: Pytest
-        env:
-          PYTHONWARNINGS: error
-        run: pytest -q --cov=engine --cov=dispatch --cov=policy --cov-report=term-missing --cov-fail-under=80
+        shell: bash
+        run: |
+          if [[ "${{ steps.detect-env.outputs.use_conda }}" == "true" ]]; then
+            conda run --no-capture-output -n ${{ steps.detect-env.outputs.env_name }} env PYTHONWARNINGS=error pytest -q --cov=engine --cov=dispatch --cov=policy --cov-report=term-missing --cov-fail-under=80
+          else
+            PYTHONWARNINGS=error pytest -q --cov=engine --cov=dispatch --cov=policy --cov-report=term-missing --cov-fail-under=80
+          fi
 
       - name: Upload coverage report
         if: always()
@@ -90,29 +144,3 @@ jobs:
           name: coverage-report
           path: .coverage
           if-no-files-found: ignore
-
-# Option B (Conda with pinned Python 3.11) sample configuration:
-# jobs:
-#   lint-test:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#       - uses: conda-incubator/setup-miniconda@v3
-#         with:
-#           python-version: 3.11
-#           environment-name: bluesky-env
-#           auto-activate-base: false
-#       - name: Install Conda dependencies
-#         env:
-#           CONDA_NO_PLUGINS: true
-#         run: |
-#           conda install -n bluesky-env -y pandas pytest pytest-cov --solver=classic
-#       - name: Run checks with Conda
-#         env:
-#           PYTHONWARNINGS: error
-#         run: |
-#           conda run --no-capture-output -n bluesky-env ruff check .
-#           conda run --no-capture-output -n bluesky-env mypy --config-file pyproject.toml
-#           conda run --no-capture-output -n bluesky-env pytest -q \
-#             --cov=engine --cov=dispatch --cov=policy \
-#             --cov-report=term-missing --cov-fail-under=80

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,4 @@ unit_tests/test_logs/electricity/prices/elec_price.csv
 *.zip
 
 # Legacy dependency manifests replaced by root requirements.txt
-environment.yml
 requirements-dev.txt

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
-name: bsky
+name: bluesky
 channels:
   - conda-forge
-  - bioconda
-  - defaults
 dependencies:
   - python=3.12
   - pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,25 @@
 
 # Core runtime dependencies
 numpy
-pandas>=2.0.0,<3.0
+pandas>=2.0
 pyomo
 scipy
-streamlit
+streamlit>=1.25
 toml
 tomli; python_version < "3.11"
 typer>=0.12
 
-# Additional modeling libraries
+# Visualization and dashboards
+dash>=2.0
+dash-bootstrap-components>=1.6
+plotly>=5.0
+
+# Data access and utilities
+grequests
+requests
+sqlalchemy>=2.0
+
+# Graph and scientific tooling
 matplotlib
 networkx
 sympy

--- a/tests/test_requirements_guard.py
+++ b/tests/test_requirements_guard.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_only_root_requirements_file() -> None:
+    """Ensure the repository keeps a single pip requirements manifest."""
+    repo_root = Path(__file__).resolve().parents[1]
+    requirements = {
+        path.resolve()
+        for path in repo_root.rglob('requirements*.txt')
+        if path.name.lower().startswith('requirements')
+    }
+    expected = {repo_root / 'requirements.txt'}
+
+    assert requirements == expected, (
+        'Unexpected requirements manifests detected: '
+        f"{sorted(str(path.relative_to(repo_root)) for path in requirements - expected)}"
+    )


### PR DESCRIPTION
## Summary
- expand requirements.txt so runtime, dashboard, and test tooling share a single dependency manifest
- add a top-level environment.yml and rework the Conda template to rely on requirements.txt instead of duplicating packages
- update CI to reuse the unified manifest (with optional Conda activation) and add a guard test blocking extra requirements files
- ensure the CI Pytest step only enables PYTHONWARNINGS=error inside pytest so Conda plugin deprecations no longer abort the job

## Testing
- ruff check .
- mypy --config-file pyproject.toml
- pytest -q --cov=engine --cov=dispatch --cov=policy --cov-report=term-missing --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_e_68d2cf69c8e48327865f9ace8f417322