### PR TITLE
Ensure pandas is required for GUI runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "main"
 version = "0.1.0"
 requires-python = ">=3.10"
+dependencies = [
+    "pandas>=2.0",
+]
 
 [tool.setuptools.packages.find]
 include = ["main", "main.*", "src", "src.*"]


### PR DESCRIPTION
## Summary
- import pandas at module import time and retain the last import error for clearer diagnostics in the Streamlit GUI
- add a dedicated handler that surfaces a helpful Streamlit error when pandas is missing and prevent the UI from continuing
- declare pandas>=2.0 as a project dependency in pyproject.toml so packaging installs it for the GUI

## Testing
- pytest tests/test_gui_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d3fa9668b4832798d3b36888ef7a34