### PR TITLE
Require pandas for Streamlit GUI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,3 +184,23 @@ PY
           name: coverage-report
           path: .coverage
           if-no-files-found: ignore
+
+  streamlit-smoke-test:
+    runs-on: ubuntu-latest
+    needs: lint-test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies for Streamlit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Show Streamlit help
+        run: python -m streamlit run app.py --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "main"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "pandas>=2.0",
+    "pandas>=2.2,<3.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # Core runtime dependencies
 numpy
-pandas>=2.0
+pandas>=2.2,<3.0
 pyomo
 scipy
 streamlit>=1.25

--- a/tests/test_gui_backend.py
+++ b/tests/test_gui_backend.py
@@ -3,7 +3,8 @@ import io
 import shutil
 
 import pytest
-import pandas as pd
+
+pd = pytest.importorskip("pandas")
 
 from tests.fixtures.dispatch_single_minimal import baseline_frames
 from gui.app import run_policy_simulation
@@ -225,17 +226,6 @@ def test_backend_returns_error_for_invalid_frames():
     )
 
     assert "error" in result
-
-
-def test_backend_reports_missing_pandas(monkeypatch):
-    config = _baseline_config()
-
-    monkeypatch.setattr("gui.app._PANDAS_MODULE", None)
-
-    result = run_policy_simulation(config, start_year=2025, end_year=2025)
-
-    assert "error" in result
-    assert "pandas" in result["error"].lower()
 
 
 def test_backend_builds_default_frames(tmp_path):


### PR DESCRIPTION
## Summary
- import pandas directly in the Streamlit GUI module, remove the optional dependency guards, and present a generic assumption-table warning when defaults fail to load
- raise the pandas requirement to `>=2.2,<3.0`, update the GUI backend tests to skip when pandas is missing, and remove the legacy missing-pandas assertions
- extend the CI workflow with a Streamlit smoke-test job that installs dependencies before invoking `streamlit run`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3ffc8241c83279661290fac6e4a06