### PR TITLE
Fix io_loader import fallback for Streamlit GUI

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, TypeVar
+import sys
 
 import pandas as pd
 
@@ -45,7 +46,11 @@ try:  # pragma: no cover - optional dependency
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     _RUN_END_TO_END = None
 
-from io_loader import Frames
+try:
+    from io_loader import Frames
+except ModuleNotFoundError:  # pragma: no cover - fallback when root not on sys.path
+    sys.path.append(str(PROJECT_ROOT))
+    from io_loader import Frames
 
 FramesType = Frames
 


### PR DESCRIPTION
## Summary
- ensure the Streamlit app can locate `io_loader` by appending the project root to `sys.path` when needed
- add the missing `sys` import used for the fallback path handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4072c9b4c832786357b5fbb36d52c