### PR TITLE
Fix general configuration indentation and session reset logic

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -427,34 +427,28 @@ def _render_general_config_section(
     if slider_min_value > slider_max_value:
         slider_min_value, slider_max_value = slider_max_value, slider_min_value
 
- if st is not None:
-    config_state_key = 'general_config_active_label'
-    if st.session_state.get(config_state_key) != config_label:
-        st.session_state[config_state_key] = config_label
-        for reset_key in (
-            'general_year_range_min_text',
-            'general_year_range_max_text',
-            'general_year_range_min_numeric',
-            'general_year_range_max_numeric',
-            'general_regions',
-            _GENERAL_REGIONS_NORMALIZED_KEY,
-            'general_year_range_slider',
-            'general_year_range_slider_bounds',
+    if st is not None:
+        config_state_key = 'general_config_active_label'
+        bounds_state_key = 'general_year_range_slider_bounds'
+        if (
+            st.session_state.get(config_state_key) != config_label
+            or st.session_state.get(bounds_state_key) != slider_bounds
         ):
-            st.session_state.pop(reset_key, None)
-
-        if st.session_state.get(config_state_key) != config_label or st.session_state.get(bounds_state_key) != slider_bounds:
             st.session_state[config_state_key] = config_label
-        # Reset stale session state keys
-        for reset_key in (
-            'general_year_range_min_text',
-            'general_year_range_max_text',
-            'general_year_range_min_numeric',
-            'general_year_range_max_numeric',
-            'general_year_range_slider',
-            'general_regions',
-        ):
-            st.session_state.pop(reset_key, None)
+            # Reset stale session state keys when the active configuration
+            # changes or when the slider bounds shift.
+            for reset_key in (
+                'general_year_range_min_text',
+                'general_year_range_max_text',
+                'general_year_range_min_numeric',
+                'general_year_range_max_numeric',
+                'general_regions',
+                _GENERAL_REGIONS_NORMALIZED_KEY,
+                'general_year_range_slider',
+                bounds_state_key,
+            ):
+                st.session_state.pop(reset_key, None)
+        st.session_state[bounds_state_key] = slider_bounds
 
         # Ensure numeric/text defaults
         min_numeric_key = 'general_year_range_min_numeric'
@@ -650,7 +644,7 @@ def _render_general_config_section(
     if st is not None:  # pragma: no branch - streamlit only when available
         st.session_state[_GENERAL_REGIONS_NORMALIZED_KEY] = list(selected_regions_raw)
 
-all_selected = 'All' in selected_regions_raw
+    all_selected = 'All' in selected_regions_raw
 
     label_to_value: dict[str, int | str] = {
         str(value): value for value in available_region_values


### PR DESCRIPTION
## Summary
- fix the misplaced indentation in the general configuration UI logic so the module imports correctly
- reset relevant Streamlit session state when the active configuration or slider bounds change and persist the bounds for future runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41273b2ec8327968b5d78c7bd6b40