### PR TITLE
Stabilize general slider state handling

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -420,169 +420,152 @@ def _render_general_config_section(
     slider_min_default = int(min(2025, year_min, start_default, end_default))
     slider_max_default = int(max(2030, year_max, start_default, end_default))
 
+    def _sanitize_year_range(
+        raw_min: Any,
+        raw_max: Any,
+        *,
+        fallback: tuple[int, int],
+    ) -> tuple[int, int]:
+        fallback_min, fallback_max = fallback
+        candidate_min = _coerce_year(raw_min, fallback_min)
+        candidate_max = _coerce_year(raw_max, fallback_max)
+        candidate_min = int(candidate_min)
+        candidate_max = int(candidate_max)
+        candidate_min = max(slider_min_default, min(slider_max_default, candidate_min))
+        candidate_max = max(slider_min_default, min(slider_max_default, candidate_max))
+        if candidate_min > candidate_max:
+            candidate_min, candidate_max = candidate_max, candidate_min
+        return candidate_min, candidate_max
+
     slider_min_value = int(start_default)
     slider_max_value = int(end_default)
-
+    sanitized_slider_state = _sanitize_year_range(
+        slider_min_value,
+        slider_max_value,
+        fallback=(slider_min_value, slider_max_value),
+    )
+    slider_min_value, slider_max_value = sanitized_slider_state
     slider_bounds = (slider_min_default, slider_max_default)
-    if slider_min_value > slider_max_value:
-        slider_min_value, slider_max_value = slider_max_value, slider_min_value
 
- if st is not None:
-    config_state_key = 'general_config_active_label'
-    if st.session_state.get(config_state_key) != config_label:
-        st.session_state[config_state_key] = config_label
-        for reset_key in (
-            'general_year_range_min_text',
-            'general_year_range_max_text',
-            'general_year_range_min_numeric',
-            'general_year_range_max_numeric',
-            'general_regions',
-            _GENERAL_REGIONS_NORMALIZED_KEY,
-            'general_year_range_slider',
-            'general_year_range_slider_bounds',
-        ):
-            st.session_state.pop(reset_key, None)
-
-        if st.session_state.get(config_state_key) != config_label or st.session_state.get(bounds_state_key) != slider_bounds:
-            st.session_state[config_state_key] = config_label
-        # Reset stale session state keys
-        for reset_key in (
-            'general_year_range_min_text',
-            'general_year_range_max_text',
-            'general_year_range_min_numeric',
-            'general_year_range_max_numeric',
-            'general_year_range_slider',
-            'general_regions',
-        ):
-            st.session_state.pop(reset_key, None)
-
-        # Ensure numeric/text defaults
+    if st is not None:
+        slider_key = 'general_year_range_slider'
+        config_state_key = 'general_config_active_label'
+        bounds_state_key = 'general_year_range_slider_bounds'
         min_numeric_key = 'general_year_range_min_numeric'
         max_numeric_key = 'general_year_range_max_numeric'
-        st.session_state.setdefault(min_numeric_key, int(slider_min_default))
-        st.session_state.setdefault(max_numeric_key, int(slider_max_default))
-        st.session_state.setdefault('general_year_range_min_text', str(st.session_state[min_numeric_key]))
-        st.session_state.setdefault('general_year_range_max_text', str(st.session_state[max_numeric_key]))
+        min_text_key = 'general_year_range_min_text'
+        max_text_key = 'general_year_range_max_text'
 
-        # Parse values from text inputs or fallback to numeric defaults
-        slider_min_value = _coerce_year(
-            st.session_state.get('general_year_range_min_text'),
-            st.session_state[min_numeric_key],
+        if (
+            st.session_state.get(config_state_key) != config_label
+            or st.session_state.get(bounds_state_key) != slider_bounds
+        ):
+            st.session_state[config_state_key] = config_label
+            # Reset stale session state keys when the active configuration
+            # changes or when the slider bounds shift.
+            for reset_key in (
+                min_text_key,
+                max_text_key,
+                min_numeric_key,
+                max_numeric_key,
+                'general_regions',
+                _GENERAL_REGIONS_NORMALIZED_KEY,
+                slider_key,
+                bounds_state_key,
+            ):
+                st.session_state.pop(reset_key, None)
+
+        st.session_state[bounds_state_key] = slider_bounds
+
+        slider_range = sanitized_slider_state
+        st.session_state.setdefault(min_numeric_key, slider_range[0])
+        st.session_state.setdefault(max_numeric_key, slider_range[1])
+        st.session_state.setdefault(min_text_key, str(slider_range[0]))
+        st.session_state.setdefault(max_text_key, str(slider_range[1]))
+
+        slider_range = _sanitize_year_range(
+            st.session_state.get(min_text_key),
+            st.session_state.get(max_text_key),
+            fallback=slider_range,
         )
-        slider_max_value = _coerce_year(
-            st.session_state.get('general_year_range_max_text'),
-            st.session_state[max_numeric_key],
-        )
 
-        # Clamp within defaults
-        slider_min_value = max(slider_min_default, min(slider_max_default, int(slider_min_value)))
-        slider_max_value = max(slider_min_default, min(slider_max_default, int(slider_max_value)))
-        if slider_min_value > slider_max_value:
-            slider_min_value, slider_max_value = slider_max_value, slider_min_value
+        st.session_state[min_numeric_key], st.session_state[max_numeric_key] = slider_range
+        st.session_state[min_text_key] = str(slider_range[0])
+        st.session_state[max_text_key] = str(slider_range[1])
 
-        sanitized_slider_state = (slider_min_value, slider_max_value)
-        st.session_state[min_numeric_key] = slider_min_value
-        st.session_state[max_numeric_key] = slider_max_value
-        st.session_state['general_year_range_min_text'] = str(slider_min_value)
-        st.session_state['general_year_range_max_text'] = str(slider_max_value)
-
-        # Build slider kwargs
         slider_kwargs: dict[str, Any] = {
             'min_value': slider_min_default,
             'max_value': slider_max_default,
-            'value': sanitized_slider_state,
+            'value': slider_range,
             'step': 1,
             'format': '%d',
-            'key': 'general_year_range_slider',
+            'key': slider_key,
         }
 
         slider_widgets_available = hasattr(container, 'slider')
         if slider_widgets_available:
             slider_value = container.slider('Run years', **slider_kwargs)
             if isinstance(slider_value, tuple):
-                slider_min_value, slider_max_value = slider_value
-            else:  # Fallback for single-year sliders
-                slider_min_value = slider_value
-                slider_max_value = slider_value
+                slider_candidate = slider_value
+            else:  # pragma: no cover - fallback for single-year sliders
+                slider_candidate = (slider_value, slider_value)
+            slider_range = _sanitize_year_range(
+                slider_candidate[0],
+                slider_candidate[1],
+                fallback=slider_range,
+            )
 
-        slider_min_value = int(slider_min_value)
-        slider_max_value = int(slider_max_value)
-        slider_min_value = max(slider_min_default, min(slider_max_default, slider_min_value))
-        slider_max_value = max(slider_min_default, min(slider_max_default, slider_max_value))
-        if slider_min_value > slider_max_value:
-            slider_min_value, slider_max_value = slider_max_value, slider_min_value
-
-        slider_widgets_available = hasattr(container, 'slider')
         if slider_widgets_available:
             try:
                 start_col, end_col = container.columns(2)
             except Exception:
                 start_col = container
                 end_col = container
+        else:
+            start_col = container
+            end_col = container
 
-            if hasattr(start_col, 'text_input'):
-                start_text = start_col.text_input(
-                    'Start year',
-                    value=st.session_state['general_year_range_min_text'],
-                    key='general_year_range_min_text',
-                )
-            else:  # pragma: no cover - fallback for non-streamlit containers
-                start_text = st.session_state['general_year_range_min_text']
-
-            if hasattr(end_col, 'text_input'):
-                end_text = end_col.text_input(
-                    'End year',
-                    value=st.session_state['general_year_range_max_text'],
-                    key='general_year_range_max_text',
-                )
-            else:  # pragma: no cover - fallback for non-streamlit containers
-                end_text = st.session_state['general_year_range_max_text']
-
-            slider_min_value = _coerce_year(start_text, slider_min_value)
-            slider_max_value = _coerce_year(end_text, slider_max_value)
-            slider_min_value = int(slider_min_value)
-            slider_max_value = int(slider_max_value)
-            slider_min_value = max(slider_min_default, min(slider_max_default, slider_min_value))
-            slider_max_value = max(slider_min_default, min(slider_max_default, slider_max_value))
-            if slider_min_value > slider_max_value:
-                slider_min_value, slider_max_value = slider_max_value, slider_min_value
-
-            slider_value = container.slider(
-                'Run years',
-                min_value=slider_min_default,
-                max_value=slider_max_default,
-                value=(slider_min_value, slider_max_value),
-                step=1,
-                format='%d',
-                key='general_year_range_slider',
+        if hasattr(start_col, 'text_input'):
+            start_text = start_col.text_input(
+                'Start year',
+                value=str(slider_range[0]),
+                key=min_text_key,
             )
-            if isinstance(slider_value, tuple):
-                slider_min_value, slider_max_value = slider_value
-            else:  # pragma: no cover - slider fallback when tuple unsupported
-                slider_min_value = slider_value
-                slider_max_value = slider_value
+        else:  # pragma: no cover - fallback for non-streamlit containers
+            start_text = st.session_state[min_text_key]
 
-            slider_min_value = int(slider_min_value)
-            slider_max_value = int(slider_max_value)
-            slider_min_value = max(slider_min_default, min(slider_max_default, slider_min_value))
-            slider_max_value = max(slider_min_default, min(slider_max_default, slider_max_value))
-            if slider_min_value > slider_max_value:
-                slider_min_value, slider_max_value = slider_max_value, slider_min_value
+        if hasattr(end_col, 'text_input'):
+            end_text = end_col.text_input(
+                'End year',
+                value=str(slider_range[1]),
+                key=max_text_key,
+            )
+        else:  # pragma: no cover - fallback for non-streamlit containers
+            end_text = st.session_state[max_text_key]
 
-        st.session_state[min_numeric_key] = slider_min_value
-        st.session_state[max_numeric_key] = slider_max_value
-        st.session_state['general_year_range_min_text'] = str(slider_min_value)
-        st.session_state['general_year_range_max_text'] = str(slider_max_value)
+        slider_range = _sanitize_year_range(
+            start_text,
+            end_text,
+            fallback=slider_range,
+        )
 
-    slider_min_value = int(slider_min_value)
-    slider_max_value = int(slider_max_value)
-    slider_min_value = max(slider_min_default, min(slider_max_default, slider_min_value))
-    slider_max_value = max(slider_min_default, min(slider_max_default, slider_max_value))
-    if slider_min_value > slider_max_value:
-        slider_min_value, slider_max_value = slider_max_value, slider_min_value
+        st.session_state[min_numeric_key], st.session_state[max_numeric_key] = slider_range
+        st.session_state[min_text_key] = str(slider_range[0])
+        st.session_state[max_text_key] = str(slider_range[1])
+        st.session_state[slider_key] = slider_range
+
+        sanitized_slider_state = slider_range
+        slider_min_value, slider_max_value = slider_range
+
+    slider_min_value, slider_max_value = _sanitize_year_range(
+        slider_min_value,
+        slider_max_value,
+        fallback=sanitized_slider_state,
+    )
+    sanitized_slider_state = (slider_min_value, slider_max_value)
 
     if st is not None:
-        st.session_state['general_year_range_slider'] = (slider_min_value, slider_max_value)
+        st.session_state['general_year_range_slider'] = sanitized_slider_state
 
     start_year = slider_min_value
     end_year = slider_max_value
@@ -650,7 +633,7 @@ def _render_general_config_section(
     if st is not None:  # pragma: no branch - streamlit only when available
         st.session_state[_GENERAL_REGIONS_NORMALIZED_KEY] = list(selected_regions_raw)
 
-all_selected = 'All' in selected_regions_raw
+    all_selected = 'All' in selected_regions_raw
 
     label_to_value: dict[str, int | str] = {
         str(value): value for value in available_region_values


### PR DESCRIPTION
## Summary
- add a helper to coerce and clamp year range selections in one place
- refactor the Streamlit session state logic so slider, text inputs, and stored bounds stay synchronized when configs or bounds change
- persist the sanitized range back to the session state after every update

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41273b2ec8327968b5d78c7bd6b40