### PR TITLE
Ensure year slider populates full range

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -284,8 +284,13 @@ def _select_years(
 
     if start is not None and end is not None:
         selected = [year for year in years if start <= year <= end]
-        if not selected:
-            selected = list(range(start, end + 1))
+        complete_range = range(start, end + 1)
+        if selected:
+            selected_set = set(selected)
+            selected_set.update(complete_range)
+            selected = sorted(selected_set)
+        else:
+            selected = list(complete_range)
         years = selected
     elif start is not None:
         selected = [year for year in years if year >= start]

--- a/tests/test_gui_backend.py
+++ b/tests/test_gui_backend.py
@@ -303,5 +303,9 @@ def test_year_and_selection_helpers_cover_branches():
     selected = _select_years(fallback_years, start_year=2023, end_year=2024)
     assert selected == [2023, 2024]
 
+    sparse_years = [2025, 2030]
+    expanded = _select_years(sparse_years, start_year=2025, end_year=2030)
+    assert expanded == [2025, 2026, 2027, 2028, 2029, 2030]
+
     with pytest.raises(ValueError):
         _select_years(years, start_year=2026, end_year=2024)


### PR DESCRIPTION
## Summary
- update the year selection helper to always include the full inclusive range between the chosen bounds
- add regression coverage to confirm sparse configuration years expand to contiguous ranges

## Testing
- pytest tests/test_gui_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d432b305808327aba1d480d3614dab