### PR TITLE
Return carbon module settings from sidebar renderer

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -120,13 +120,7 @@ SIDEBAR_STYLE = """
 
 _download_directory_fallback_used = False
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Mapping, Iterable
-
-
 @dataclass
-
 class GeneralConfigResult:
     """Container for user-selected general configuration settings."""
 
@@ -371,6 +365,27 @@ class DispatchModuleSettings:
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass
+class IncentivesModuleSettings:
+    """Record of incentives sidebar selections."""
+
+    enabled: bool
+    production_credits: list[dict[str, Any]]
+    investment_credits: list[dict[str, Any]]
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class OutputsModuleSettings:
+    """Record of outputs sidebar selections."""
+
+    enabled: bool
+    directory: str
+    resolved_path: Path
+    show_csv_downloads: bool
+    errors: list[str] = field(default_factory=list)
+
+
 # -------------------------
 # Utilities
 # -------------------------
@@ -588,59 +603,6 @@ def _normalize_region_labels(
 
 
 # -------------------------
-# Dataclasses
-# -------------------------
-@dataclass
-class GeneralConfigResult:
-    config_label: str
-    config_source: Any
-    run_config: dict[str, Any]
-    candidate_years: list[int]
-    start_year: int
-    end_year: int
-    selected_years: list[int]
-    regions: list[int | str]
-
-
-@dataclass
-class CarbonModuleSettings:
-    enabled: bool
-    enable_floor: bool
-    enable_ccr: bool
-    ccr1_enabled: bool
-    ccr2_enabled: bool
-    banking_enabled: bool
-    control_period_years: int | None
-    errors: list[str] = field(default_factory=list)
-
-
-@dataclass
-class DispatchModuleSettings:
-    enabled: bool
-    mode: str
-    capacity_expansion: bool
-    reserve_margins: bool
-    errors: list[str] = field(default_factory=list)
-
-
-@dataclass
-class IncentivesModuleSettings:
-    enabled: bool
-    production_credits: list[dict[str, Any]]
-    investment_credits: list[dict[str, Any]]
-    errors: list[str] = field(default_factory=list)
-
-
-@dataclass
-class OutputsModuleSettings:
-    enabled: bool
-    directory: str
-    resolved_path: Path
-    show_csv_downloads: bool
-    errors: list[str] = field(default_factory=list)
-
-
-# -------------------------
 # General Config UI
 # -------------------------
 def _render_general_config_section(
@@ -798,10 +760,10 @@ def _render_general_config_section(
 def _render_carbon_policy_section(
     container: Any,
     run_config: dict[str, Any],
-) -> None:
+) -> CarbonModuleSettings:
     """Render the carbon policy section wrapper."""
     # You can decide whether to call render_carbon_module_controls here
-    render_carbon_module_controls(run_config, container)
+    return render_carbon_module_controls(run_config, container)
 
 
 def render_carbon_module_controls(run_config: dict[str, Any], container) -> CarbonModuleSettings:
@@ -3008,6 +2970,8 @@ def main() -> None:
         banking_enabled=False,
         control_period_years=None,
         price_per_ton=0.0,
+        price_schedule={},
+        errors=[],
     )
     dispatch_settings = DispatchModuleSettings(
         enabled=False,


### PR DESCRIPTION
## Summary
- return the carbon sidebar renderer's settings dataclass so the caller receives populated fields

## Testing
- python -m compileall gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d460db75cc8327be9c0ee4986db3fe