### PR TITLE
Fix carbon module controls region options handling

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -884,10 +884,19 @@ def _render_carbon_policy_section(
 ) -> CarbonModuleSettings:
     """Render the carbon policy section wrapper."""
     # You can decide whether to call render_carbon_module_controls here
-    return render_carbon_module_controls(run_config, container)
+    return render_carbon_module_controls(
+        run_config,
+        container,
+        region_options=region_options,
+    )
 
 
-def render_carbon_module_controls(run_config: dict[str, Any], container) -> CarbonModuleSettings:
+def render_carbon_module_controls(
+    run_config: dict[str, Any],
+    container,
+    *,
+    region_options: Iterable[int | str] | None = None,
+) -> CarbonModuleSettings:
     """Render the carbon policy module controls."""
 
     modules = run_config.setdefault("modules", {})


### PR DESCRIPTION
## Summary
- pass the available region options to the carbon module controls renderer
- accept region options explicitly in the carbon controls helper to avoid undefined variable access

## Testing
- python -m compileall gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a3362760832785af0a47e9dca893