### PR TITLE
Integrate carbon price schedule into dispatch cost handling

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -710,12 +710,16 @@ def _dispatch_from_frames(
     *,
     use_network: bool = False,
     period_weights: Mapping[Any, float] | None = None,
+    carbon_price_schedule: Mapping[int, float]
+    | Mapping[str, Any]
+    | float
+    | None = None,
 ) -> Callable[[Any, float], object]:
     """Build a dispatch callback that solves using the frame container."""
 
     _ensure_pandas()
 
-    frames_obj = Frames.coerce(frames)
+    frames_obj = Frames.coerce(frames, carbon_price_schedule=carbon_price_schedule)
 
     weights: dict[object, float] = {}
     if period_weights:
@@ -786,13 +790,59 @@ def _dispatch_from_frames(
             )
         return result
 
+    schedule_lookup: dict[int | None, float] = {}
+
+    def _ingest_schedule(payload: Mapping[Any, Any] | float | None) -> None:
+        if payload is None:
+            return
+        if isinstance(payload, Mapping):
+            for key, value in payload.items():
+                try:
+                    year = int(key) if key is not None else None
+                except (TypeError, ValueError):
+                    continue
+                try:
+                    schedule_lookup[year] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            return
+        try:
+            schedule_lookup[None] = float(payload)
+        except (TypeError, ValueError):
+            return
+
+    _ingest_schedule(frames_obj.carbon_price_schedule)
+    _ingest_schedule(carbon_price_schedule)
+
+    def _price_for(period: Any) -> float:
+        if not schedule_lookup:
+            return 0.0
+        try:
+            year_key = int(period)
+        except (TypeError, ValueError):
+            year_key = None
+        if year_key is not None and year_key in schedule_lookup:
+            return float(schedule_lookup[year_key])
+        normalized = _normalize_progress_year(period)
+        if isinstance(normalized, int) and normalized in schedule_lookup:
+            return float(schedule_lookup[normalized])
+        if None in schedule_lookup:
+            return float(schedule_lookup[None])
+        return 0.0
+
     def dispatch(year: Any, allowance_cost: float):
         weight = _weight_for(year)
         frames_for_year = _scaled_frames(year, weight)
+        carbon_adder = _price_for(year)
+        effective_allowance_cost = float(allowance_cost) + carbon_adder
         if use_network:
-            raw_result = solve_network_from_frames(frames_for_year, year, allowance_cost)
+            raw_result = solve_network_from_frames(
+                frames_for_year, year, effective_allowance_cost
+            )
         else:
-            raw_result = solve_single(year, allowance_cost, frames=frames_for_year)
+            raw_result = solve_single(
+                year, effective_allowance_cost, frames=frames_for_year
+            )
         return _scale_result(raw_result, weight)
 
     return dispatch
@@ -807,12 +857,16 @@ def run_fixed_point_from_frames(
     max_iter: int = 25,
     relaxation: float = 0.5,
     use_network: bool = False,
+    carbon_price_schedule: Mapping[int, float]
+    | Mapping[str, Any]
+    | float
+    | None = None,
 ) -> dict[int, dict]:
     """Run the annual fixed-point integration using in-memory frames."""
 
     _ensure_pandas()
 
-    frames_obj = Frames.coerce(frames)
+    frames_obj = Frames.coerce(frames, carbon_price_schedule=carbon_price_schedule)
     policy_spec = frames_obj.policy()
     policy = policy_spec.to_policy()
     years_sequence = _coerce_years(policy, years)
@@ -821,6 +875,7 @@ def run_fixed_point_from_frames(
         frames_obj,
         use_network=use_network,
         period_weights=period_weights,
+        carbon_price_schedule=carbon_price_schedule,
     )
 
     def dispatch_model(year: int, allowance_cost: float) -> float:
@@ -1091,7 +1146,7 @@ def run_end_to_end_from_frames(
 
     _ensure_pandas()
 
-    frames_obj = Frames.coerce(frames)
+    frames_obj = Frames.coerce(frames, carbon_price_schedule=carbon_price_schedule)
     policy_spec = frames_obj.policy()
     policy = policy_spec.to_policy()
     years_sequence = _coerce_years(policy, years)
@@ -1100,6 +1155,7 @@ def run_end_to_end_from_frames(
         frames_obj,
         use_network=use_network,
         period_weights=period_weights,
+        carbon_price_schedule=carbon_price_schedule,
     )
     years_sequence = list(years_sequence)
     total_years = len(years_sequence)

--- a/gui/app.py
+++ b/gui/app.py
@@ -2313,6 +2313,7 @@ def _build_default_frames(
     *,
     carbon_policy_enabled: bool = True,
     banking_enabled: bool = True,
+    carbon_price_schedule: Mapping[int, float] | Mapping[str, Any] | None = None,
 ) -> FramesType:
     frames_cls = FramesType
     demand_records = [
@@ -2329,6 +2330,7 @@ def _build_default_frames(
         base_frames,
         carbon_policy_enabled=carbon_policy_enabled,
         banking_enabled=banking_enabled,
+        carbon_price_schedule=carbon_price_schedule,
     )
 
 
@@ -3052,6 +3054,10 @@ def run_policy_simulation(
     )
 
     merged_modules["carbon_price"] = price_cfg.as_dict()
+    price_schedule_map = {
+        int(year): float(value) for year, value in price_cfg.schedule.items()
+    }
+    price_active = bool(price_cfg.active and price_schedule_map)
     normalized_regions: list[Any] = []
     if cap_regions is not None:
         seen_labels: set[str] = set()
@@ -3105,17 +3111,23 @@ def run_policy_simulation(
     config["start_year"] = int(years[0])
     config["end_year"] = int(years[-1])
 
+    carbon_price_for_frames: Mapping[int, float] | None = (
+        price_schedule_map if price_active else None
+    )
+
     if frames is None:
         frames_obj = _build_default_frames(
             years,
             carbon_policy_enabled=bool(carbon_policy_enabled),
             banking_enabled=bool(allowance_banking_enabled),
+            carbon_price_schedule=carbon_price_for_frames,
         )
     else:
         frames_obj = Frames.coerce(
             frames,
             carbon_policy_enabled=bool(carbon_policy_enabled),
             banking_enabled=bool(allowance_banking_enabled),
+            carbon_price_schedule=carbon_price_for_frames,
         )
 
     try:
@@ -3124,100 +3136,110 @@ def run_policy_simulation(
         LOGGER.exception("Unable to normalise demand frame for requested years")
         return {"error": str(exc)}
 
-    if normalized_regions:
-        region_label_map: dict[str, Any] = {str(region): region for region in normalized_regions}
+    region_label_map: dict[str, Any] = {str(region): region for region in normalized_regions}
 
-        def _ingest_region_values(values: Sequence[Any] | pd.Series | None) -> None:
-            if values is None:
-                return
-            if isinstance(values, pd.Series):
-                iterable = values.dropna().unique()
-            else:
-                iterable = values
-            for value in iterable:
-                if value is None:
-                    continue
-                if pd.isna(value):
-                    continue
-                region_label_map.setdefault(str(value), value)
-
-        demand_region_labels: set[str] = set()
-        try:
-            demand_df = frames_obj.demand()
-        except Exception:
-            demand_df = None
-        if demand_df is not None and not demand_df.empty:
-            _ingest_region_values(demand_df["region"])
-            demand_region_labels = {str(region) for region in demand_df["region"].unique()}
-
-        existing_coverage_df: pd.DataFrame | None = None
-        for frame_name in ("units", "coverage"):
-            try:
-                frame_candidate = frames_obj.optional_frame(frame_name)
-            except Exception:
-                frame_candidate = None
-            if frame_candidate is not None and not frame_candidate.empty and "region" in frame_candidate.columns:
-                _ingest_region_values(frame_candidate["region"])
-                if frame_name == "coverage":
-                    existing_coverage_df = frame_candidate.copy()
-
-        if not demand_region_labels:
-            demand_region_labels = set(region_label_map)
-
-        normalized_existing: pd.DataFrame | None = None
-        existing_keys: set[tuple[str, int]] = set()
-        if existing_coverage_df is not None and not existing_coverage_df.empty:
-            normalized_existing = existing_coverage_df.copy()
-            if not isinstance(normalized_existing.index, pd.RangeIndex):
-                normalized_existing = normalized_existing.reset_index(drop=True)
-            index_names = getattr(normalized_existing.index, "names", None) or []
-            if "region" not in normalized_existing.columns and "region" in index_names:
-                normalized_existing = normalized_existing.reset_index()
-            if "region" not in normalized_existing.columns:
-                normalized_existing = normalized_existing.assign(region=pd.Series(dtype=object))
-            if "year" not in normalized_existing.columns:
-                normalized_existing = normalized_existing.assign(year=-1)
-            if "covered" not in normalized_existing.columns:
-                normalized_existing = normalized_existing.assign(covered=False)
-            normalized_existing = normalized_existing.loc[:, ["region", "year", "covered"]]
-            normalized_existing["year"] = pd.to_numeric(
-                normalized_existing["year"], errors="coerce"
-            ).fillna(-1).astype(int)
-            normalized_existing["covered"] = normalized_existing["covered"].astype(bool)
-            existing_keys = {
-                (str(region), int(year))
-                for region, year in zip(normalized_existing["region"], normalized_existing["year"])
-            }
-
-        coverage_records: list[dict[str, Any]] = []
-        selected_labels = {str(region) for region in normalized_regions}
-        for label in sorted({*demand_region_labels, *selected_labels, *region_label_map.keys()}):
-            key = (label, -1)
-            if key in existing_keys:
-                continue
-            region_value = region_label_map.get(label)
-            if region_value is None:
-                try:
-                    region_value = int(label)
-                except (TypeError, ValueError):
-                    region_value = label
-            coverage_records.append(
-                {
-                    "region": region_value,
-                    "year": -1,
-                    "covered": label in selected_labels,
-                }
-            )
-
-        if coverage_records:
-            coverage_df = pd.DataFrame(coverage_records, columns=["region", "year", "covered"])
+    def _ingest_region_values(values: Sequence[Any] | pd.Series | None) -> None:
+        if values is None:
+            return
+        if isinstance(values, pd.Series):
+            iterable = values.dropna().unique()
         else:
-            coverage_df = pd.DataFrame(columns=["region", "year", "covered"])
-        if normalized_existing is not None:
-            coverage_df = pd.concat([normalized_existing, coverage_df], ignore_index=True)
-        coverage_df = coverage_df.sort_values(["region", "year"]).reset_index(drop=True)
-        frames_obj = frames_obj.with_frame("coverage", coverage_df)
+            iterable = values
+        for value in iterable:
+            if value is None:
+                continue
+            if pd.isna(value):
+                continue
+            region_label_map.setdefault(str(value), value)
 
+    demand_region_labels: set[str] = set()
+    try:
+        demand_df = frames_obj.demand()
+    except Exception:
+        demand_df = None
+    if demand_df is not None and not demand_df.empty:
+        _ingest_region_values(demand_df["region"])
+        demand_region_labels = {str(region) for region in demand_df["region"].unique()}
+
+    existing_coverage_df: pd.DataFrame | None = None
+    for frame_name in ("units", "coverage"):
+        try:
+            frame_candidate = frames_obj.optional_frame(frame_name)
+        except Exception:
+            frame_candidate = None
+        if frame_candidate is not None and not frame_candidate.empty and "region" in frame_candidate.columns:
+            _ingest_region_values(frame_candidate["region"])
+            if frame_name == "coverage":
+                existing_coverage_df = frame_candidate.copy()
+
+    coverage_selection = list(normalized_coverage or [])
+    cover_all = coverage_selection == ["All"]
+    coverage_labels = (
+        {str(label) for label in coverage_selection if str(label) and str(label) != "All"}
+        if not cover_all
+        else set()
+    )
+    for label in coverage_labels:
+        region_label_map.setdefault(label, label)
+
+    if not demand_region_labels:
+        demand_region_labels = set(region_label_map) or set(coverage_labels)
+
+    normalized_existing: pd.DataFrame | None = None
+    existing_keys: set[tuple[str, int]] = set()
+    if existing_coverage_df is not None and not existing_coverage_df.empty:
+        normalized_existing = existing_coverage_df.copy()
+        if not isinstance(normalized_existing.index, pd.RangeIndex):
+            normalized_existing = normalized_existing.reset_index(drop=True)
+        index_names = getattr(normalized_existing.index, "names", None) or []
+        if "region" not in normalized_existing.columns and "region" in index_names:
+            normalized_existing = normalized_existing.reset_index()
+        if "region" not in normalized_existing.columns:
+            normalized_existing = normalized_existing.assign(region=pd.Series(dtype=object))
+        if "year" not in normalized_existing.columns:
+            normalized_existing = normalized_existing.assign(year=-1)
+        if "covered" not in normalized_existing.columns:
+            normalized_existing = normalized_existing.assign(covered=False)
+        normalized_existing = normalized_existing.loc[:, ["region", "year", "covered"]]
+        normalized_existing["year"] = pd.to_numeric(
+            normalized_existing["year"], errors="coerce"
+        ).fillna(-1).astype(int)
+        normalized_existing["covered"] = normalized_existing["covered"].astype(bool)
+        existing_keys = {
+            (str(region), int(year))
+            for region, year in zip(normalized_existing["region"], normalized_existing["year"])
+        }
+
+    coverage_records: list[dict[str, Any]] = []
+    label_candidates = {*demand_region_labels, *coverage_labels, *region_label_map.keys()}
+    for label in sorted(label_candidates):
+        key = (label, -1)
+        if key in existing_keys:
+            continue
+        region_value = region_label_map.get(label)
+        if region_value is None:
+            try:
+                region_value = int(label)
+            except (TypeError, ValueError):
+                region_value = label
+        coverage_records.append(
+            {
+                "region": region_value,
+                "year": -1,
+                "covered": True if cover_all else label in coverage_labels,
+            }
+        )
+
+    if coverage_records:
+        coverage_df = pd.DataFrame(coverage_records, columns=["region", "year", "covered"])
+    else:
+        coverage_df = pd.DataFrame(columns=["region", "year", "covered"])
+    if normalized_existing is not None:
+        coverage_df = pd.concat([normalized_existing, coverage_df], ignore_index=True)
+    coverage_df = coverage_df.sort_values(["region", "year"]).reset_index(drop=True)
+    frames_obj = frames_obj.with_frame("coverage", coverage_df)
+
+    if normalized_regions:
         config_regions = list(dict.fromkeys(list(config.get("regions", [])) + normalized_regions))
         config["regions"] = config_regions
 
@@ -3263,9 +3285,6 @@ def run_policy_simulation(
         and carbon_policy_cfg.enable_ccr
         and (carbon_policy_cfg.ccr1_enabled or carbon_policy_cfg.ccr2_enabled)
     )
-    price_schedule_map = dict(price_cfg.schedule)
-    price_active = price_cfg.active
-
     try:
         outputs = runner(
             frames_obj,
@@ -3908,6 +3927,9 @@ def main() -> None:
                     selected_years or [start_year_val],
                     carbon_policy_enabled=carbon_settings.enabled,
                     banking_enabled=carbon_settings.banking_enabled,
+                    carbon_price_schedule=(
+                        carbon_settings.price_schedule if carbon_settings.price_enabled else None
+                    ),
                 )
             except Exception as exc:  # pragma: no cover - defensive UI path
                 frames_for_run = None
@@ -3987,6 +4009,9 @@ def main() -> None:
                 selected_years or [start_year_val],
                 carbon_policy_enabled=bool(carbon_settings.enabled),
                 banking_enabled=bool(carbon_settings.banking_enabled),
+                carbon_price_schedule=(
+                    carbon_settings.price_schedule if carbon_settings.price_enabled else None
+                ),
             )
         except Exception as exc:  # pragma: no cover - defensive UI path
             frames_for_run = None


### PR DESCRIPTION
## Summary
- add carbon price schedule awareness to the Frames container and propagate it into the dispatch runner
- adjust dispatch cost calculation to include exogenous carbon price adders and expose the schedule controls in the GUI
- update coverage frame construction so GUI selections take effect even without explicit cap-region overrides

## Testing
- `pytest tests/test_dispatch_lp_network.py tests/test_gui_backend.py tests/test_frames_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4a78e086883279305621a59581199