### PR TITLE
Fix GUI module import when running as script

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -40,11 +40,21 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - fallback for packaged app execution
     PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-from gui.region_metadata import (
-    canonical_region_value,
-    region_alias_map,
-    region_display_label,
-)
+try:
+    from gui.region_metadata import (
+        canonical_region_value,
+        region_alias_map,
+        region_display_label,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback when run as a script
+    # ``python gui/app.py`` executes the file outside of the package context, so
+    # ``gui`` is not importable via normal absolute imports.  Import directly in
+    # that scenario so the module remains runnable without ``streamlit run``.
+    from region_metadata import (  # type: ignore[import-not-found]
+        canonical_region_value,
+        region_alias_map,
+        region_display_label,
+    )
 
 if importlib.util.find_spec("streamlit") is not None:  # pragma: no cover - optional dependency
     import streamlit as st  # type: ignore[import-not-found]


### PR DESCRIPTION
## Summary
- add a fallback import path for `gui.region_metadata` so `python gui/app.py` runs without raising ModuleNotFoundError

## Testing
- `pytest` *(fails: tests/test_policy_supply.py::test_ccr_tiers_unlock_by_year et al. due to unexpected keyword argument 'carbon_price_schedule' in fake_dispatch_from_frames)*

------
https://chatgpt.com/codex/tasks/task_e_68d5265731148327a243bc5081e2dd67