### PR TITLE
Fix confirm run modal state handling

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -4015,24 +4015,25 @@ def main() -> None:
             cancel_clicked = cancel_col.button('Cancel', key='cancel_run')
             return confirm_clicked, cancel_clicked
 
-        confirm_clicked = False
-        cancel_clicked = False
+        confirm_clicked = bool(st.session_state.get('confirm_run'))
+        cancel_clicked = bool(st.session_state.get('cancel_run'))
 
-        if use_dialog and hasattr(st, "dialog"):
-            clicks: dict[str, bool] = {'confirm': False, 'cancel': False}
+        if not confirm_clicked and not cancel_clicked:
+            if use_dialog and hasattr(st, "dialog"):
+                clicks: dict[str, bool] = {'confirm': False, 'cancel': False}
 
-            @st.dialog('Confirm model run')
-            def _show_confirm_dialog() -> None:
-                confirm, cancel = _render_confirm_modal()
-                clicks['confirm'] = confirm
-                clicks['cancel'] = cancel
+                @st.dialog('Confirm model run')
+                def _show_confirm_dialog() -> None:
+                    confirm, cancel = _render_confirm_modal()
+                    clicks['confirm'] = confirm
+                    clicks['cancel'] = cancel
 
-            _show_confirm_dialog()
-            confirm_clicked = clicks['confirm']
-            cancel_clicked = clicks['cancel']
-        else:
-            with st.expander('Confirm model run'):
-                confirm_clicked, cancel_clicked = _render_confirm_modal()
+                _show_confirm_dialog()
+                confirm_clicked = clicks['confirm']
+                cancel_clicked = clicks['cancel']
+            else:
+                with st.expander('Confirm model run'):
+                    confirm_clicked, cancel_clicked = _render_confirm_modal()
 
         if cancel_clicked:
             st.session_state.pop('pending_run', None)


### PR DESCRIPTION
## Summary
- avoid re-rendering the confirm run modal when a confirm or cancel click has already been recorded
- rely on the stored button state to process the action so that the modal closes and the run proceeds with progress feedback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4ae4359408327ab40f719871330d8