### PR TITLE
Integrate carbon price into dispatch costs

### DIFF
--- a/dispatch/stub.py
+++ b/dispatch/stub.py
@@ -27,7 +27,11 @@ _REGION_PRICES: Dict[str, float] = {
 }
 
 
-def solve(year: int, allowance_cost: float) -> DispatchResult:
+def solve(
+    year: int,
+    allowance_cost: float,
+    carbon_price: float = 0.0,
+) -> DispatchResult:
     """Return a deterministic dispatch result.
 
     Parameters
@@ -37,10 +41,14 @@ def solve(year: int, allowance_cost: float) -> DispatchResult:
         generation by fuel.
     allowance_cost:
         Carbon allowance price in dollars per ton. Emissions respond linearly
-        using ``E = max(0, a - b * allowance_cost)``.
+        to the combined effect of ``allowance_cost`` and ``carbon_price`` using
+        ``E = max(0, a - b * (allowance_cost + carbon_price))``.
+    carbon_price:
+        Exogenous carbon price applied to all emissions in dollars per ton.
     """
 
-    emissions = max(0.0, EMISSIONS_INTERCEPT - EMISSIONS_SLOPE * allowance_cost)
+    effective_price = float(allowance_cost) + float(carbon_price)
+    emissions = max(0.0, EMISSIONS_INTERCEPT - EMISSIONS_SLOPE * effective_price)
 
     # Keep the generation mix dynamic across years while maintaining the same
     # proportions between fuels.

--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -291,7 +291,7 @@ def _build_allowance_supply(
 
 
 def _solve_allowance_market_year(
-    dispatch_solver: Callable[[int, float], object],
+    dispatch_solver: Callable[[int, float, float], object],
     year: int,
     supply: AllowanceSupply,
     bank_prev: float,
@@ -304,6 +304,7 @@ def _solve_allowance_market_year(
     annual_surrender_frac: float,
     carry_pct: float,
     banking_enabled: bool,
+    carbon_price: float = 0.0,
     progress_cb: ProgressCallback | None = None,
 ) -> dict[str, object]:
     """Solve for the allowance clearing price for ``year`` using bisection.
@@ -381,7 +382,9 @@ def _solve_allowance_market_year(
 
     if not policy_enabled or not supply.enabled:
         clearing_price = 0.0
-        dispatch_result = dispatch_solver(year, clearing_price)
+        dispatch_result = dispatch_solver(
+            year, clearing_price, carbon_price=carbon_price
+        )
         emissions = _extract_emissions(dispatch_result)
         allowances = max(supply.available_allowances(clearing_price), emissions)
         ccr1_issued, ccr2_issued = _issued_quantities(clearing_price, allowances)
@@ -422,7 +425,7 @@ def _solve_allowance_market_year(
     low = max(0.0, float(min_price))
     high = max(low, high_price if high_price > 0.0 else low)
 
-    dispatch_low = dispatch_solver(year, low)
+    dispatch_low = dispatch_solver(year, low, carbon_price=carbon_price)
     emissions_low = _extract_emissions(dispatch_low)
     allowances_low = supply.available_allowances(low)
 
@@ -430,7 +433,9 @@ def _solve_allowance_market_year(
     if total_allowances_low >= emissions_low:
         clearing_price = supply.enforce_floor(low)
         if clearing_price != low:
-            dispatch_low = dispatch_solver(year, clearing_price)
+            dispatch_low = dispatch_solver(
+                year, clearing_price, carbon_price=carbon_price
+            )
             emissions_low = _extract_emissions(dispatch_low)
             allowances_low = supply.available_allowances(clearing_price)
             total_allowances_low = bank_prev + allowances_low
@@ -471,14 +476,16 @@ def _solve_allowance_market_year(
         }
         return _finalize(result)
 
-    dispatch_high = dispatch_solver(year, high)
+    dispatch_high = dispatch_solver(year, high, carbon_price=carbon_price)
     emissions_high = _extract_emissions(dispatch_high)
     allowances_high = supply.available_allowances(high)
 
     if bank_prev + allowances_high < emissions_high - tol:
         clearing_price = supply.enforce_floor(high)
         if clearing_price != high:
-            dispatch_high = dispatch_solver(year, clearing_price)
+            dispatch_high = dispatch_solver(
+                year, clearing_price, carbon_price=carbon_price
+            )
             emissions_high = _extract_emissions(dispatch_high)
             allowances_high = supply.available_allowances(clearing_price)
         total_allowances_high = bank_prev + allowances_high
@@ -530,7 +537,7 @@ def _solve_allowance_market_year(
 
     for iteration in range(1, max_iter_int + 1):
         mid = 0.5 * (low_bound + high_bound)
-        dispatch_mid = dispatch_solver(year, mid)
+        dispatch_mid = dispatch_solver(year, mid, carbon_price=carbon_price)
         emissions_mid = _extract_emissions(dispatch_mid)
         allowances_mid = supply.available_allowances(mid)
         total_allowances_mid = bank_prev + allowances_mid
@@ -558,7 +565,9 @@ def _solve_allowance_market_year(
 
     clearing_price = supply.enforce_floor(best_price)
     if clearing_price != best_price:
-        best_dispatch = dispatch_solver(year, clearing_price)
+        best_dispatch = dispatch_solver(
+            year, clearing_price, carbon_price=carbon_price
+        )
         best_emissions = _extract_emissions(best_dispatch)
         best_allowances = supply.available_allowances(clearing_price)
     total_allowances = bank_prev + best_allowances
@@ -710,7 +719,7 @@ def _dispatch_from_frames(
     *,
     use_network: bool = False,
     period_weights: Mapping[Any, float] | None = None,
-) -> Callable[[Any, float], object]:
+) -> Callable[[Any, float, float], object]:
     """Build a dispatch callback that solves using the frame container."""
 
     _ensure_pandas()
@@ -786,13 +795,23 @@ def _dispatch_from_frames(
             )
         return result
 
-    def dispatch(year: Any, allowance_cost: float):
+    def dispatch(year: Any, allowance_cost: float, carbon_price: float = 0.0):
         weight = _weight_for(year)
         frames_for_year = _scaled_frames(year, weight)
         if use_network:
-            raw_result = solve_network_from_frames(frames_for_year, year, allowance_cost)
+            raw_result = solve_network_from_frames(
+                frames_for_year,
+                year,
+                allowance_cost,
+                carbon_price=carbon_price,
+            )
         else:
-            raw_result = solve_single(year, allowance_cost, frames=frames_for_year)
+            raw_result = solve_single(
+                year,
+                allowance_cost,
+                frames=frames_for_year,
+                carbon_price=carbon_price,
+            )
         return _scale_result(raw_result, weight)
 
     return dispatch
@@ -824,7 +843,9 @@ def run_fixed_point_from_frames(
     )
 
     def dispatch_model(year: int, allowance_cost: float) -> float:
-        return _extract_emissions(dispatch_solver(year, allowance_cost))
+        return _extract_emissions(
+            dispatch_solver(year, allowance_cost, carbon_price=0.0)
+        )
 
     return run_annual_fixed_point(
         policy,
@@ -840,7 +861,7 @@ def run_fixed_point_from_frames(
 def _build_engine_outputs(
     years: Sequence[Any],
     raw_results: Mapping[Any, Mapping[str, object]],
-    dispatch_solver: Callable[[Any, float], object],
+    dispatch_solver: Callable[..., object],
     policy: RGGIPolicyAnnual,
 ) -> EngineOutputs:
     """Convert fixed-point results into structured engine outputs."""
@@ -857,7 +878,7 @@ def _build_engine_outputs(
         price = float(summary.get("p_co2", 0.0))
         dispatch_result = summary.pop("_dispatch_result", None)
         if dispatch_result is None:
-            dispatch_result = dispatch_solver(period, price)
+            dispatch_result = dispatch_solver(period, price, carbon_price=0.0)
         emissions_total = float(summary.get("emissions", _extract_emissions(dispatch_result)))
 
         compliance_year = getattr(policy, "compliance_year_for", None)
@@ -1145,13 +1166,16 @@ def run_end_to_end_from_frames(
                 },
             )
 
+        carbon_price_value = _price_for_year(year)
+
         if not policy_enabled_global:
-            price = _price_for_year(year)
-            dispatch_result = dispatch_solver(year, price)
+            dispatch_result = dispatch_solver(
+                year, 0.0, carbon_price=carbon_price_value
+            )
             emissions = _extract_emissions(dispatch_result)
             summary_disabled: dict[str, object] = {
                 'year': year,
-                'p_co2': float(price),
+                'p_co2': float(carbon_price_value),
                 'available_allowances': float(emissions),
                 'allowances_total': float(emissions),
                 'bank_prev': 0.0,
@@ -1181,7 +1205,7 @@ def run_end_to_end_from_frames(
                         "index": idx,
                         "total_years": total_years,
                         "shortage": False,
-                        "price": float(price),
+                        "price": float(carbon_price_value),
                         "iterations": 0,
                     },
                 )
@@ -1249,6 +1273,7 @@ def run_end_to_end_from_frames(
             annual_surrender_frac=surrender_frac,
             carry_pct=carry_pct,
             banking_enabled=banking_enabled_year,
+            carbon_price=carbon_price_value,
             progress_cb=progress_cb,
         )
 

--- a/tests/test_allowance_annual.py
+++ b/tests/test_allowance_annual.py
@@ -171,7 +171,10 @@ def test_clear_year_matches_bisection_solver(emissions, enable_ccr):
         enable_ccr=bool(policy.ccr1_enabled or policy.ccr2_enabled),
     )
 
-    def dispatch_stub(_year: int, _price: float) -> dict[str, float]:
+    def dispatch_stub(
+        _year: int, _price: float, carbon_price: float = 0.0
+    ) -> dict[str, float]:
+        assert carbon_price >= 0.0  # unused but ensures signature compatibility
         return {"emissions_tons": float(emissions)}
 
     summary = _solve_allowance_market_year(

--- a/tests/test_carbon_disabled.py
+++ b/tests/test_carbon_disabled.py
@@ -130,7 +130,12 @@ def test_policy_disabled_applies_carbon_price_schedule():
     annual = outputs.annual.set_index("year")
     assert annual.loc[years[0], "p_co2"] == pytest.approx(price_value)
 
-    dispatch = solve_single(years[0], price_value, frames=frames)
+    dispatch = solve_single(
+        years[0],
+        0.0,
+        frames=frames,
+        carbon_price=price_value,
+    )
     assert annual.loc[years[0], "emissions_tons"] == pytest.approx(dispatch.emissions_tons)
 
 

--- a/tests/test_dispatch_lp_network.py
+++ b/tests/test_dispatch_lp_network.py
@@ -142,8 +142,10 @@ def test_imports_increase_with_carbon_price() -> None:
         }
     )
 
-    low_price = solve_from_frames(frames, 2030, allowance_cost=0.0)
-    high_price = solve_from_frames(frames, 2030, allowance_cost=40.0)
+    low_price = solve_from_frames(frames, 2030, allowance_cost=0.0, carbon_price=0.0)
+    high_price = solve_from_frames(
+        frames, 2030, allowance_cost=0.0, carbon_price=40.0
+    )
 
     assert low_price.imports_to_covered == pytest.approx(0.0, abs=1e-6)
     assert high_price.imports_to_covered > low_price.imports_to_covered

--- a/tests/test_dispatch_lp_single.py
+++ b/tests/test_dispatch_lp_single.py
@@ -79,6 +79,18 @@ def test_emissions_decline_with_allowance_cost() -> None:
     assert all(a >= b - 1e-9 for a, b in zip(emissions, emissions[1:]))
 
 
+def test_emissions_decline_with_carbon_price() -> None:
+    """An exogenous carbon price should suppress emissions."""
+
+    prices = [0.0, 15.0, 45.0]
+    emissions: list[float] = []
+    for price in prices:
+        result = solve(2030, 0.0, frames=baseline_frames(), carbon_price=price)
+        emissions.append(result.emissions_tons)
+
+    assert all(a >= b - 1e-9 for a, b in zip(emissions, emissions[1:]))
+
+
 def test_generation_respects_capacity_limits() -> None:
     """No unit may exceed its annual energy capability."""
 


### PR DESCRIPTION
## Summary
- embed carbon price alongside allowance costs in dispatch marginal cost calculations for the network, single-node, and stub solvers
- propagate exogenous carbon prices through the engine run loop, including allowance market clearing and scaling logic
- extend the dispatch-related test suite to cover carbon price impacts and verify emissions decline with higher prices

## Testing
- pytest tests/test_dispatch_lp_single.py tests/test_dispatch_lp_network.py tests/test_carbon_disabled.py tests/test_allowance_annual.py

------
https://chatgpt.com/codex/tasks/task_e_68d4ae0d69b483279c56ed905ce67e19