### PR TITLE
Guard pending run session state

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -3847,6 +3847,9 @@ def main() -> None:
         show_csv_downloads=False,
     )
     run_clicked = False
+    pending_run: Mapping[str, Any] | None = None
+    show_confirm_modal = False
+    run_in_progress = False
 
     with st.sidebar:
         st.markdown(SIDEBAR_STYLE, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- initialize `pending_run`, `show_confirm_modal`, and `run_in_progress` to safe defaults before reading Streamlit session state in the GUI run workflow
- prevent NameError when no pending run metadata has been created yet

## Testing
- `pytest` *(fails: numerous existing engine dispatch tests error because fake dispatch helpers do not accept new carbon pricing arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68d53930d86c8327a07ac807534d8ff3