### PR TITLE
Fix pending run confirmation state reset

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -4117,7 +4117,12 @@ def main() -> None:
             pending_run = None
             show_confirm_modal = False
 
-# Trigger showing modal if a run is pending
+    # Refresh pending run reference after any confirm/cancel handling
+    pending_run = st.session_state.get("pending_run")
+    if not isinstance(pending_run, Mapping):
+        pending_run = None
+
+    # Trigger showing modal if a run is pending
     if isinstance(pending_run, Mapping) and not show_confirm_modal and not run_in_progress:
         show_confirm_modal = True
         st.session_state["show_confirm_modal"] = True


### PR DESCRIPTION
## Summary
- refresh the cached `pending_run` value from Streamlit session state after confirm/cancel handling
- guard against non-mapping session entries before toggling the confirmation modal

## Testing
- python -m compileall gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d53aa5fc1883279c9a62428870d129