### PR TITLE
Ensure carbon coverage selector lists all regions

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -42,6 +42,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for packaged app exec
 
 try:
     from gui.region_metadata import (
+        DEFAULT_REGION_METADATA,
         canonical_region_label,
         canonical_region_value,
         region_alias_map,
@@ -52,6 +53,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when run as a script
     # ``gui`` is not importable via normal absolute imports.  Import directly in
     # that scenario so the module remains runnable without ``streamlit run``.
     from region_metadata import (  # type: ignore[import-not-found]
+        DEFAULT_REGION_METADATA,
         canonical_region_label,
         canonical_region_value,
         region_alias_map,
@@ -993,6 +995,12 @@ def render_carbon_module_controls(
             return
         if label not in coverage_labels:
             coverage_labels.append(label)
+
+    # Always include the default 25-region dataset in the coverage options so the
+    # multiselect remains comprehensive even when the base configuration only
+    # lists a subset of regions.
+    for default_region in DEFAULT_REGION_METADATA:
+        _register_coverage_value(default_region)
 
     if region_options is not None:
         for entry in region_options:


### PR DESCRIPTION
## Summary
- always include the default 25-region dataset when building the carbon coverage multiselect options
- import the default region metadata in both package and script execution paths so the selector can reference every region

## Testing
- pytest tests *(fails: existing dispatch helper signature mismatch in engine/run_loop.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d54244f2288327986dcf230ebb69ef