### PR TITLE
Import GeneralConfigResult for general UI

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -44,6 +44,7 @@ try:
     from gui.module_settings import (
         CarbonModuleSettings,
         DispatchModuleSettings,
+        GeneralConfigResult,
         IncentivesModuleSettings,
         OutputsModuleSettings,
     )
@@ -51,6 +52,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility fallback
     from module_settings import (  # type: ignore[import-not-found]
         CarbonModuleSettings,
         DispatchModuleSettings,
+        GeneralConfigResult,
         IncentivesModuleSettings,
         OutputsModuleSettings,
     )


### PR DESCRIPTION
## Summary
- import `GeneralConfigResult` into the Streamlit app module
- ensure the general configuration section can instantiate the result dataclass without raising a NameError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d54ac782908327a473b1118c142b6b