### PR TITLE
Fix GUI engine import fallback

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -99,7 +99,12 @@ else:  # pragma: no cover - optional dependency
 try:  # pragma: no cover - optional dependency
     from engine.run_loop import run_end_to_end_from_frames as _RUN_END_TO_END
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    _RUN_END_TO_END = None
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.append(str(PROJECT_ROOT))
+    try:  # pragma: no cover - optional dependency
+        from engine.run_loop import run_end_to_end_from_frames as _RUN_END_TO_END
+    except ModuleNotFoundError:
+        _RUN_END_TO_END = None
 
 try:
     from io_loader import Frames


### PR DESCRIPTION
## Summary
- ensure the GUI adds the project root to `sys.path` when the engine module cannot be imported so that the run engine is always available when Streamlit is launched from outside the repo root

## Testing
- pytest *(fails: policy supply tests expect the fake dispatch stub to accept the new carbon_price_schedule kwarg)*

------
https://chatgpt.com/codex/tasks/task_e_68d574ba08e08327ac70cfb6ec5cf249