### PR TITLE
Fix confirm run modal button handling

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -4764,7 +4764,10 @@ def main() -> None:
             c1, c2 = st.columns(2)
             ok = c1.button("Confirm Run", type="primary", key="confirm_run")
             cancel = c2.button("Cancel", key="cancel_run")
-            return ok, cancel
+
+            confirm_state = bool(st.session_state.get("confirm_run"))
+            cancel_state = bool(st.session_state.get("cancel_run"))
+            return ok or confirm_state, cancel or cancel_state
 
         confirm_clicked = False
         cancel_clicked = False


### PR DESCRIPTION
## Summary
- ensure the confirm run modal also respects Streamlit session state values for the confirm and cancel buttons
- prevent missed clicks in the dialog so the simulation run starts when the user confirms

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d585c209e483279ff6bb3941ea96f3