### PR TITLE
Add deep carbon pricing integration

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -1164,6 +1164,7 @@ def _render_carbon_policy_section(
     modules = run_config.setdefault("modules", {})
     defaults = modules.get("carbon_policy", {}) or {}
     price_defaults = modules.get("carbon_price", {}) or {}
+    dispatch_defaults = modules.get("electricity_dispatch", {}) or {}
 
     # -------------------------
     # Defaults
@@ -1248,6 +1249,12 @@ def _render_carbon_policy_section(
             return
         st.session_state["carbon_module_last_changed"] = key
 
+    deep_pricing_allowed = bool(dispatch_defaults.get("deep_carbon_pricing", False))
+    if st is not None:
+        deep_pricing_allowed = bool(
+            st.session_state.get("dispatch_deep_carbon", deep_pricing_allowed)
+        )
+
     session_enabled_default = enabled_default
     session_price_default = price_enabled_default
     last_changed = None
@@ -1259,7 +1266,7 @@ def _render_carbon_policy_section(
         session_price_default = bool(
             st.session_state.get("carbon_price_enable", price_enabled_default)
         )
-        if session_enabled_default and session_price_default:
+        if session_enabled_default and session_price_default and not deep_pricing_allowed:
             if last_changed == "cap":
                 session_price_default = False
             else:
@@ -1451,7 +1458,7 @@ def _render_carbon_policy_section(
     # Errors and Return
     # -------------------------
     errors: list[str] = []
-    if enabled and price_enabled:
+    if enabled and price_enabled and not deep_pricing_allowed:
         errors.append("Cannot enable both carbon cap and carbon price simultaneously.")
 
     cap_region_values: list[Any] = []
@@ -1545,6 +1552,7 @@ def _render_dispatch_section(
         mode_default = "single"
     capacity_default = bool(defaults.get("capacity_expansion", True))
     reserve_default = bool(defaults.get("reserve_margins", True))
+    deep_default = bool(defaults.get("deep_carbon_pricing", False))
 
     enabled = container.toggle(
         "Enable electricity dispatch",
@@ -1555,6 +1563,7 @@ def _render_dispatch_section(
     mode_value = mode_default
     capacity_expansion = capacity_default
     reserve_margins = reserve_default
+    deep_carbon_pricing = deep_default
     errors: list[str] = []
 
     mode_options = {"single": "Single region", "network": "Networked"}
@@ -1580,6 +1589,16 @@ def _render_dispatch_section(
             value=reserve_default,
             disabled=not enabled,
             key="dispatch_reserve",
+        )
+        deep_carbon_pricing = panel.toggle(
+            "Enable deep carbon pricing",
+            value=deep_default,
+            disabled=not enabled,
+            key="dispatch_deep_carbon",
+            help=(
+                "Allows simultaneous use of allowance clearing prices and exogenous "
+                "carbon prices when solving dispatch."
+            ),
         )
 
         if enabled:
@@ -1607,12 +1626,14 @@ def _render_dispatch_section(
 
     if not enabled:
         mode_value = mode_value or "single"
+        deep_carbon_pricing = False
 
     modules["electricity_dispatch"] = {
         "enabled": bool(enabled),
         "mode": mode_value or "single",
         "capacity_expansion": bool(capacity_expansion),
         "reserve_margins": bool(reserve_margins),
+        "deep_carbon_pricing": bool(deep_carbon_pricing),
     }
 
     return DispatchModuleSettings(
@@ -1620,6 +1641,7 @@ def _render_dispatch_section(
         mode=mode_value or "single",
         capacity_expansion=bool(capacity_expansion),
         reserve_margins=bool(reserve_margins),
+        deep_carbon_pricing=bool(deep_carbon_pricing),
         errors=errors,
     )
 
@@ -3260,6 +3282,7 @@ def run_policy_simulation(
     carbon_price_value: float | None = None,
     carbon_price_schedule: Mapping[int, float] | Mapping[str, Any] | None = None,
     dispatch_use_network: bool = False,
+    deep_carbon_pricing: bool = False,
     module_config: Mapping[str, Any] | None = None,
     frames: FramesType | Mapping[str, pd.DataFrame] | None = None,
     assumption_notes: Iterable[str] | None = None,
@@ -3305,7 +3328,10 @@ def run_policy_simulation(
         years=years,
     )
 
-    if price_cfg.active:
+    if price_cfg.active and bool(carbon_policy_enabled) and not deep_carbon_pricing:
+        return {"error": "Cannot enable both carbon cap and carbon price simultaneously."}
+
+    if price_cfg.active and not deep_carbon_pricing:
         carbon_policy_cfg.disable_for_price()
 
     normalized_coverage = _normalize_coverage_selection(
@@ -3378,6 +3404,7 @@ def run_policy_simulation(
 
     dispatch_record = merged_modules.setdefault("electricity_dispatch", {})
     dispatch_record["use_network"] = bool(dispatch_use_network)
+    dispatch_record["deep_carbon_pricing"] = bool(deep_carbon_pricing)
 
     def _coerce_year_range(start: int | None, end: int | None) -> list[int]:
         if start is None and end is None:
@@ -3588,6 +3615,7 @@ def run_policy_simulation(
             enable_ccr=enable_ccr_flag,
             use_network=bool(dispatch_use_network),
             carbon_price_schedule=price_schedule_map if price_active else None,
+            deep_carbon_pricing=bool(deep_carbon_pricing),
             progress_cb=progress_cb,
         )
     except Exception as exc:  # pragma: no cover - defensive guard
@@ -4106,6 +4134,7 @@ def main() -> None:
         mode='single',
         capacity_expansion=False,
         reserve_margins=False,
+        deep_carbon_pricing=False,
     )
     incentives_settings = IncentivesModuleSettings(
         enabled=False,
@@ -4278,6 +4307,7 @@ def main() -> None:
     dispatch_use_network = bool(
         dispatch_settings.enabled and dispatch_settings.mode == "network"
     )
+    dispatch_deep_carbon = bool(dispatch_settings.deep_carbon_pricing)
 
     current_run_payload: dict[str, Any] = {
         "config_source": copy.deepcopy(run_config),
@@ -4311,6 +4341,7 @@ def main() -> None:
             else {}
         ),
         "dispatch_use_network": dispatch_use_network,
+        "dispatch_deep_carbon": bool(dispatch_settings.deep_carbon_pricing),
         "module_config": copy.deepcopy(run_config.get("modules", {})),
         "frames": frames_for_run,
         "assumption_notes": list(assumption_notes),
@@ -4450,6 +4481,7 @@ def main() -> None:
     dispatch_use_network = bool(
         dispatch_settings.enabled and dispatch_settings.mode == 'network'
     )
+    dispatch_deep_carbon = bool(dispatch_settings.deep_carbon_pricing)
 
     if run_inputs is not None:
         run_config = copy.deepcopy(run_inputs.get('config_source', run_config))
@@ -4457,6 +4489,9 @@ def main() -> None:
         end_year_val = int(run_inputs.get('end_year', end_year_val))
         dispatch_use_network = bool(
             run_inputs.get('dispatch_use_network', dispatch_use_network)
+        )
+        dispatch_deep_carbon = bool(
+            run_inputs.get('dispatch_deep_carbon', dispatch_deep_carbon)
         )
 
     result = st.session_state.get('last_result')
@@ -4576,6 +4611,9 @@ def main() -> None:
                     ),
                     dispatch_use_network=bool(
                         inputs_for_run.get('dispatch_use_network', dispatch_use_network)
+                    ),
+                    deep_carbon_pricing=bool(
+                        inputs_for_run.get('dispatch_deep_carbon', dispatch_deep_carbon)
                     ),
                     module_config=inputs_for_run.get(
                         'module_config', run_config.get('modules', {})

--- a/gui/module_settings.py
+++ b/gui/module_settings.py
@@ -49,6 +49,7 @@ class DispatchModuleSettings:
     mode: str
     capacity_expansion: bool
     reserve_margins: bool
+    deep_carbon_pricing: bool
     errors: list[str] = field(default_factory=list)
 
 

--- a/tests/test_gui_backend.py
+++ b/tests/test_gui_backend.py
@@ -226,6 +226,7 @@ def test_backend_dispatch_and_carbon_modules(monkeypatch):
         policy = frames.policy().to_policy()
         captured["carbon_enabled"] = policy.enabled
         captured["use_network"] = kwargs.get("use_network")
+        captured["deep_carbon_pricing"] = kwargs.get("deep_carbon_pricing")
         return real_runner(frames, **kwargs)
 
     monkeypatch.setattr("gui.app._ensure_engine_runner", lambda: capturing_runner)
@@ -257,11 +258,76 @@ def test_backend_dispatch_and_carbon_modules(monkeypatch):
     assert "error" not in result
     assert captured.get("carbon_enabled") is True
     assert captured.get("use_network") is True
+    assert captured.get("deep_carbon_pricing") is False
     dispatch_cfg = result["module_config"]["electricity_dispatch"]
     assert dispatch_cfg["enabled"] is True
     assert dispatch_cfg["use_network"] is True
+    assert dispatch_cfg.get("deep_carbon_pricing") is False
     carbon_cfg = result["module_config"]["carbon_policy"]
     assert carbon_cfg.get("regions") == [1]
+
+    _cleanup_temp_dir(result)
+
+
+def test_backend_mutual_exclusion_without_deep():
+    config = _baseline_config()
+    frames = _frames_for_years([2025])
+
+    result = run_policy_simulation(
+        config,
+        start_year=2025,
+        end_year=2025,
+        frames=frames,
+        carbon_policy_enabled=True,
+        cap_regions=[1],
+        carbon_price_enabled=True,
+        carbon_price_value=25.0,
+        deep_carbon_pricing=False,
+    )
+
+    assert result.get("error") == "Cannot enable both carbon cap and carbon price simultaneously."
+
+
+def test_backend_deep_carbon_combines_prices(monkeypatch):
+    real_runner = importlib.import_module("engine.run_loop").run_end_to_end_from_frames
+    captured: dict[str, object] = {}
+
+    def capturing_runner(frames, **kwargs):
+        captured["deep_carbon_pricing"] = kwargs.get("deep_carbon_pricing")
+        return real_runner(frames, **kwargs)
+
+    monkeypatch.setattr("gui.app._ensure_engine_runner", lambda: capturing_runner)
+
+    config = _baseline_config()
+    frames = _frames_for_years([2025])
+
+    result = run_policy_simulation(
+        config,
+        start_year=2025,
+        end_year=2025,
+        frames=frames,
+        carbon_policy_enabled=True,
+        cap_regions=[1],
+        carbon_price_enabled=True,
+        carbon_price_value=15.0,
+        deep_carbon_pricing=True,
+    )
+
+    assert "error" not in result
+    assert captured.get("deep_carbon_pricing") is True
+
+    annual = result["annual"]
+    row = annual.loc[annual["year"] == 2025].iloc[0]
+    allowance_price = float(row["p_co2_allowance"])
+    exogenous_price = float(row["p_co2_exogenous"])
+    effective_price = float(row["p_co2_effective"])
+
+    assert row["p_co2"] == pytest.approx(allowance_price)
+    assert exogenous_price == pytest.approx(15.0)
+    assert effective_price == pytest.approx(allowance_price + exogenous_price)
+
+    dispatch_cfg = result["module_config"].get("electricity_dispatch", {})
+    assert dispatch_cfg.get("deep_carbon_pricing") is True
 
     _cleanup_temp_dir(result)
 


### PR DESCRIPTION
## Summary
- add a deep carbon pricing toggle in the dispatch UI and persist the setting through run payloads
- refactor the dispatch engine to combine allowance and exogenous carbon prices with new logging and output fields
- extend backend tests to cover deep carbon pricing behaviour and mutual exclusion handling

## Testing
- pytest tests/test_gui_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d56fe809508327a7b18482c1da09c1