### PR TITLE
Fix missing parenthesis in policy simulation call

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -4926,7 +4926,8 @@ def main() -> None:
                     deep_carbon_pricing=bool(
                         inputs_for_run.get(
                             "dispatch_deep_carbon",
-                            getattr(dispatch_settings, "deep_carbon_pricing", False)
+                            getattr(dispatch_settings, "deep_carbon_pricing", False),
+                        )
                     ),
 
                     module_config=inputs_for_run.get(


### PR DESCRIPTION
## Summary
- close the run_policy_simulation call in gui/app.py by adding the missing parentheses around the deep_carbon_pricing argument
- ensure the boolean and lookup calls in that argument are balanced so the module parses correctly

## Testing
- python -m compileall gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d59350634483278f9d37cf202eb93d