### PR TITLE
Handle deep carbon compatibility with legacy runners

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -938,7 +938,6 @@ def run_fixed_point_from_frames(
         use_network=use_network,
         period_weights=period_weights,
         carbon_price_schedule=carbon_price_schedule,
-        deep_carbon_pricing=deep_carbon_pricing,
     )
     if deep_carbon_pricing:
         dispatch_kwargs["deep_carbon_pricing"] = bool(deep_carbon_pricing)
@@ -1236,7 +1235,6 @@ def run_end_to_end_from_frames(
         use_network=use_network,
         period_weights=period_weights,
         carbon_price_schedule=carbon_price_schedule,
-        deep_carbon_pricing=deep_carbon_pricing,
     )
     if deep_carbon_pricing:
         dispatch_kwargs["deep_carbon_pricing"] = bool(deep_carbon_pricing)


### PR DESCRIPTION
## Summary
- avoid passing the deep_carbon_pricing flag to dispatch solvers unless the mode is enabled, keeping legacy dispatch helpers compatible
- reset cached runner signature details when the engine runner changes and improve detection of deep carbon support so the GUI returns the right message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5994cb4c88327bd2e762c3a4c04ad