### PR TITLE
Fix general_regions widget initialization conflict

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -1255,9 +1255,6 @@ def _render_general_config_section(
         else:
             canonical_existing = previous_clean_selection
 
-        if list(existing_entries) != canonical_existing:
-            st.session_state["general_regions"] = list(canonical_existing)
-
         previous_clean_selection = canonical_existing
     else:
         previous_clean_selection = list(default_selection)
@@ -1266,7 +1263,7 @@ def _render_general_config_section(
         container.multiselect(
             "Regions",
             options=region_labels,
-            default=default_selection,
+            default=previous_clean_selection,
             key="general_regions",
         )
     )


### PR DESCRIPTION
## Summary
- avoid manually setting the `general_regions` session state when the widget is instantiated
- use the previously canonicalized selection as the multiselect default to prevent Streamlit warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d699d9d218832798d7b0510aefcc77