### PR TITLE
Fix duplicate deep_carbon_pricing keyword argument

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -5201,11 +5201,6 @@ def main() -> None:
                             getattr(dispatch_settings, "deep_carbon_pricing", False),
                         )
                     ),
-                    deep_carbon_pricing=bool(
-                        inputs_for_run.get(
-                            'dispatch_deep_carbon', dispatch_settings.deep_carbon_pricing
-                        )
-                    ),
                     module_config=inputs_for_run.get(
                         "module_config", run_config.get("modules", {})
                     ),


### PR DESCRIPTION
## Summary
- remove the duplicated `deep_carbon_pricing` keyword argument when invoking the dispatch run

## Testing
- python -m compileall gui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a0b811588327b4c94c1e7ad25076