### PR TITLE
Adjust dispatch capacity expansion default

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -5713,7 +5713,7 @@ def main() -> None:
         "carbon_cap_schedule": dict(carbon_settings.cap_schedule),
         "dispatch_use_network": dispatch_use_network,
         "dispatch_capacity_expansion": bool(
-            getattr(dispatch_settings, "capacity_expansion", False)
+            getattr(dispatch_settings, "capacity_expansion", True)
         ),
         "dispatch_deep_carbon": bool(
             getattr(dispatch_settings, "deep_carbon_pricing", False)
@@ -5915,7 +5915,7 @@ def main() -> None:
                     ),
                     dispatch_capacity_expansion=inputs_for_run.get(
                         "dispatch_capacity_expansion",
-                        getattr(dispatch_settings, "capacity_expansion", False),
+                        getattr(dispatch_settings, "capacity_expansion", True),
                     ),
                     deep_carbon_pricing=bool(
                         inputs_for_run.get(


### PR DESCRIPTION
## Summary
- default the dispatch capacity expansion flag to true when no UI override is provided
- keep downstream payload reconstruction aligned with the new default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6dbb0eb8c8327a8a3b634e671c644