### PR TITLE
Align shortage flag with minted allowances

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -569,7 +569,7 @@ def _solve_allowance_market_year(
         allowances_mid = supply.available_allowances(mid)
         total_allowances_mid = bank_prev + allowances_mid
         iteration_count = iteration
-        shortage_mid = total_allowances_mid < emissions_mid
+        shortage_mid = emissions_mid > allowances_mid + tol
         _report_progress(
             "iteration",
             iteration,
@@ -577,7 +577,7 @@ def _solve_allowance_market_year(
             status="bisection",
             shortage=shortage_mid,
         )
-        if total_allowances_mid >= emissions_mid:
+        if allowances_mid + tol >= emissions_mid:
             best_price = mid
             best_allowances = allowances_mid
             best_emissions = emissions_mid
@@ -602,7 +602,7 @@ def _solve_allowance_market_year(
     surrendered = min(surrender_frac * best_emissions, total_allowances)
     bank_unadjusted = max(total_allowances - surrendered, 0.0)
     obligation = max(outstanding_prev + best_emissions - surrendered, 0.0)
-    shortage_flag = best_emissions > total_allowances + tol
+    shortage_flag = best_emissions > best_allowances + tol
     ccr1_issued, ccr2_issued = _issued_quantities(clearing_price, best_allowances)
     bank_carry = max(bank_unadjusted * carry_pct, 0.0)
 

--- a/policy/allowance_annual.py
+++ b/policy/allowance_annual.py
@@ -474,8 +474,6 @@ def clear_year(
             ccr2_final = best_ccr2
             total_allowances = bank_prev + minted_final
 
-    shortage_flag = emissions > total_allowances + tol
-
     frac = max(0.0, min(1.0, float(policy.annual_surrender_frac)))
     required_current = frac * emissions
     outstanding_before = outstanding_prev + emissions
@@ -499,6 +497,8 @@ def clear_year(
         bank_unadjusted = 0.0
         carry_pct = 0.0
     bank_new = bank_unadjusted * carry_pct
+
+    shortage_flag = emissions > minted_final + tol
 
     record = {
         'year': year,

--- a/tests/test_allowance_annual.py
+++ b/tests/test_allowance_annual.py
@@ -86,7 +86,7 @@ def test_ccr_tranches_and_shortage_flag():
     )
     assert second["ccr1_issued"] == pytest.approx(policy.ccr1_qty.loc[2026])
     assert second["ccr2_issued"] == pytest.approx(policy.ccr2_qty.loc[2026])
-    assert not second["shortage_flag"]
+    assert second["shortage_flag"]
     assert state.bank_history[2026] == pytest.approx(second["bank_new"])
 
     shortage_policy = policy_for_shortage()


### PR DESCRIPTION
## Summary
- move annual clearing shortage determination until after banking updates and base it on minted allowances
- update the annual run loop solver to use the same shortage criterion and refresh tests for the new behaviour

## Testing
- `pytest tests/test_allowance_annual.py`
- `pytest tests/test_carbon_disabled.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6ddded8608327998c362a5b85329f