### PR TITLE
Sync allowance market configuration with GUI overrides

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -4558,10 +4558,37 @@ def run_policy_simulation(
     else:
         carbon_record.pop("cap_schedule", None)
     allowance_market_record = merged_modules.setdefault("allowance_market", {})
+    allowance_market_record["enabled"] = policy_enabled
+    allowance_market_record["bank0"] = float(initial_bank_value)
+    allowance_market_record["ccr1_enabled"] = bool(
+        carbon_policy_cfg.ccr1_enabled if ccr_flag else False
+    )
+    allowance_market_record["ccr2_enabled"] = bool(
+        carbon_policy_cfg.ccr2_enabled if ccr_flag else False
+    )
     if policy_enabled and cap_schedule_map:
         allowance_market_record["cap"] = dict(sorted(cap_schedule_map.items()))
     elif not policy_enabled:
         allowance_market_record.pop("cap", None)
+
+    existing_allowance_cfg = config.get("allowance_market")
+    if isinstance(existing_allowance_cfg, Mapping):
+        allowance_config = dict(existing_allowance_cfg)
+    else:
+        allowance_config = {}
+    allowance_config["enabled"] = policy_enabled
+    allowance_config["bank0"] = float(initial_bank_value)
+    allowance_config["ccr1_enabled"] = bool(
+        carbon_policy_cfg.ccr1_enabled if ccr_flag else False
+    )
+    allowance_config["ccr2_enabled"] = bool(
+        carbon_policy_cfg.ccr2_enabled if ccr_flag else False
+    )
+    if policy_enabled and cap_schedule_map:
+        allowance_config["cap"] = dict(sorted(cap_schedule_map.items()))
+    elif not policy_enabled:
+        allowance_config.pop("cap", None)
+    config["allowance_market"] = allowance_config
     normalized_regions, unresolved_cap_regions = _normalize_cap_region_entries(cap_regions)
     if unresolved_cap_regions:
         unique_unresolved = list(dict.fromkeys(unresolved_cap_regions))

--- a/tests/test_gui_backend.py
+++ b/tests/test_gui_backend.py
@@ -924,6 +924,76 @@ def test_backend_banking_toggle_disables_bank(tmp_path, caplog):
     _cleanup_temp_dir(result)
 
 
+def test_backend_updates_allowance_market_config():
+    config = _baseline_config()
+    config["allowance_market"]["cap"] = {}
+    frames = _frames_for_years([2025, 2026])
+
+    schedule = {2025: 345_000.0, 2026: 320_000.0}
+
+    result = run_policy_simulation(
+        config,
+        start_year=2025,
+        end_year=2026,
+        frames=frames,
+        cap_regions=[1],
+        carbon_cap_schedule=schedule,
+        initial_bank=1234.0,
+        allowance_banking_enabled=True,
+        ccr1_enabled=True,
+        ccr2_enabled=False,
+    )
+
+    assert "error" not in result
+
+    allowance_module = result["module_config"]["allowance_market"]
+    allowance_config = result["config"]["allowance_market"]
+    expected_schedule = {year: float(value) for year, value in schedule.items()}
+
+    assert allowance_module["enabled"] is True
+    assert allowance_config["enabled"] is True
+    assert allowance_module["cap"] == expected_schedule
+    assert allowance_config["cap"] == expected_schedule
+    assert allowance_module["bank0"] == pytest.approx(1234.0)
+    assert allowance_config["bank0"] == pytest.approx(1234.0)
+    assert allowance_module["ccr1_enabled"] is True
+    assert allowance_module["ccr2_enabled"] is False
+    assert allowance_config["ccr1_enabled"] is True
+    assert allowance_config["ccr2_enabled"] is False
+
+    _cleanup_temp_dir(result)
+
+
+def test_backend_zeroes_allowance_bank_when_disabled_config():
+    config = _baseline_config()
+    frames = _frames_for_years([2025, 2026])
+
+    schedule = {2025: 400_000.0, 2026: 390_000.0}
+
+    result = run_policy_simulation(
+        config,
+        start_year=2025,
+        end_year=2026,
+        frames=frames,
+        cap_regions=[1],
+        carbon_cap_schedule=schedule,
+        initial_bank=9876.0,
+        allowance_banking_enabled=False,
+    )
+
+    assert "error" not in result
+
+    allowance_module = result["module_config"]["allowance_market"]
+    allowance_config = result["config"]["allowance_market"]
+
+    assert allowance_module["bank0"] == pytest.approx(0.0)
+    assert allowance_config["bank0"] == pytest.approx(0.0)
+    assert allowance_module["enabled"] is True
+    assert allowance_config["enabled"] is True
+
+    _cleanup_temp_dir(result)
+
+
 def test_backend_builds_price_schedule_for_run_years(monkeypatch):
     real_runner = importlib.import_module("engine.run_loop").run_end_to_end_from_frames
     captured: dict[str, object] = {}


### PR DESCRIPTION
## Summary
- propagate GUI carbon policy overrides to both module and top-level allowance market config
- ensure the allowance market mirrors cap schedules, CCR flags, and bank settings derived from the UI
- add regression tests covering cap schedule propagation and banking disablement behaviour

## Testing
- pytest tests/test_gui_backend.py::test_backend_updates_allowance_market_config tests/test_gui_backend.py::test_backend_zeroes_allowance_bank_when_disabled_config

------
https://chatgpt.com/codex/tasks/task_e_68d6e08ea4148327add5d4e9bf2243cb