### PR TITLE
Align annual output schema with new carbon price columns

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -14,16 +14,16 @@ except ImportError:  # pragma: no cover - optional dependency
 
 ANNUAL_OUTPUT_COLUMNS = [
     "year",
-    "allowance_price",
-    "allowance_price_allowance_component",
-    "allowance_price_exogenous_component",
-    "allowance_price_effective",
+    "p_co2",
+    "p_co2_all",
+    "p_co2_exc",
+    "p_co2_eff",
     "iterations",
     "emissions_tons",
     "allowances_minted",
     "allowances_available",
     "bank",
-    "allowances_surrendered",
+    "surrender",
     "obligation",
     "finalized",
     "shortage_flag",
@@ -1203,22 +1203,16 @@ def _build_engine_outputs(
         annual_rows.append(
             {
                 "year": year,
-                "allowance_price": price_value,
-                "allowance_price_allowance_component": float(
-                    entry.get("allowance_price_last", price_value)
-                ),
-                "allowance_price_exogenous_component": float(
-                    entry.get("exogenous_price_last", 0.0)
-                ),
-                "allowance_price_effective": float(
-                    entry.get("effective_price_last", price_value)
-                ),
+                "p_co2": price_value,
+                "p_co2_all": float(entry.get("allowance_price_last", price_value)),
+                "p_co2_exc": float(entry.get("exogenous_price_last", 0.0)),
+                "p_co2_eff": float(entry.get("effective_price_last", price_value)),
                 "iterations": iterations_value,
                 "emissions_tons": float(entry.get("emissions_sum", 0.0)),
                 "allowances_minted": minted,
                 "allowances_available": allowances_total,
                 "bank": bank_final,
-                "allowances_surrendered": surrendered_total,
+                "surrender": surrendered_total,
                 "obligation": obligation_final,
                 "finalized": finalized,
                 "shortage_flag": shortage_flag,

--- a/gui/app.py
+++ b/gui/app.py
@@ -4812,6 +4812,11 @@ def run_policy_simulation(
             first_bank = bank_series.iloc[0]
             if pd.notna(first_bank):
                 policy_bank0 = float(first_bank)
+    if not policy_bank0 and bank0_from_config is not None:
+        try:
+            policy_bank0 = float(bank0_from_config)
+        except Exception:  # pragma: no cover - defensive
+            policy_bank0 = 0.0
 
     runner = _ensure_engine_runner()
     supports_deep = True
@@ -5285,8 +5290,8 @@ def _render_results(result: Mapping[str, Any]) -> None:
         price_missing_caption = 'Allowance clearing price data unavailable for this run.'
 
     price_chart_column: str | None = None
-    if not chart_data.empty and 'allowance_price' in chart_data.columns:
-        chart_data = chart_data.rename(columns={'allowance_price': price_series_label})
+    if not chart_data.empty and 'p_co2' in chart_data.columns:
+        chart_data = chart_data.rename(columns={'p_co2': price_series_label})
         price_chart_column = price_series_label
 
     display_price_table = display_annual.copy()
@@ -5298,16 +5303,17 @@ def _render_results(result: Mapping[str, Any]) -> None:
         allowed_price_columns = [
             'year',
             price_series_label,
-            'p_co2_exogenous',
-            'p_co2_effective',
+            'p_co2_all',
+            'p_co2_exc',
+            'p_co2_eff',
             'emissions_tons',
         ]
         display_price_table = display_price_table.filter(items=allowed_price_columns)
     else:
         # Allowance output path
-        if 'allowance_price' in display_price_table.columns:
+        if 'p_co2' in display_price_table.columns:
             display_price_table = display_price_table.rename(
-                columns={'allowance_price': price_series_label}
+                columns={'p_co2': price_series_label}
             )
 
 

--- a/tests/test_carbon_disabled.py
+++ b/tests/test_carbon_disabled.py
@@ -90,7 +90,7 @@ def test_engine_matches_dispatch_when_policy_disabled():
     )
 
     annual = outputs.annual.set_index("year")
-    assert annual["allowance_price"].eq(0.0).all()
+    assert annual["p_co2"].eq(0.0).all()
     assert annual["bank"].eq(0.0).all()
     assert annual["obligation"].eq(0.0).all()
 
@@ -112,7 +112,7 @@ def test_policy_disabled_with_minimal_inputs():
     outputs = run_end_to_end_from_frames(frames, years=years)
 
     annual = outputs.annual.set_index("year")
-    assert annual.loc[years[0], "allowance_price"] == pytest.approx(0.0)
+    assert annual.loc[years[0], "p_co2"] == pytest.approx(0.0)
     assert annual.loc[years[0], "bank"] == pytest.approx(0.0)
     assert annual.loc[years[0], "obligation"] == pytest.approx(0.0)
 
@@ -128,7 +128,7 @@ def test_policy_disabled_applies_carbon_price_schedule():
     )
 
     annual = outputs.annual.set_index("year")
-    assert annual.loc[years[0], "allowance_price"] == pytest.approx(price_value)
+    assert annual.loc[years[0], "p_co2"] == pytest.approx(price_value)
 
     dispatch = solve_single(
         years[0],

--- a/tests/test_policy_supply.py
+++ b/tests/test_policy_supply.py
@@ -118,9 +118,9 @@ def test_ccr_tiers_unlock_by_year(monkeypatch: pytest.MonkeyPatch):
     )
     annual = outputs.annual.set_index("year")
 
-    assert annual.loc[2025, "allowance_price"] == pytest.approx(20.0, abs=1e-6)
+    assert annual.loc[2025, "p_co2"] == pytest.approx(20.0, abs=1e-6)
     assert annual.loc[2025, "allowances_minted"] == pytest.approx(130.0)
-    assert annual.loc[2026, "allowance_price"] == pytest.approx(50.0, abs=1e-6)
+    assert annual.loc[2026, "p_co2"] == pytest.approx(50.0, abs=1e-6)
     assert annual.loc[2026, "allowances_minted"] == pytest.approx(230.0)
 
 
@@ -169,8 +169,8 @@ def test_floor_changes_by_year(monkeypatch: pytest.MonkeyPatch):
     )
     annual = outputs.annual.set_index("year")
 
-    assert annual.loc[2027, "allowance_price"] == pytest.approx(5.0, abs=1e-6)
-    assert annual.loc[2028, "allowance_price"] == pytest.approx(15.0, abs=1e-6)
+    assert annual.loc[2027, "p_co2"] == pytest.approx(5.0, abs=1e-6)
+    assert annual.loc[2028, "p_co2"] == pytest.approx(15.0, abs=1e-6)
     assert annual.loc[2027, "allowances_minted"] == pytest.approx(200.0)
     assert annual.loc[2028, "allowances_minted"] == pytest.approx(200.0)
 
@@ -216,9 +216,9 @@ def test_toggles_disable_features(monkeypatch: pytest.MonkeyPatch):
     annual_without = without_ccr.annual.set_index("year")
 
     assert annual_with.loc[2029, "allowances_minted"] == pytest.approx(130.0)
-    assert annual_with.loc[2029, "allowance_price"] == pytest.approx(20.0, abs=1e-6)
+    assert annual_with.loc[2029, "p_co2"] == pytest.approx(20.0, abs=1e-6)
     assert annual_without.loc[2029, "allowances_minted"] == pytest.approx(100.0)
-    assert annual_without.loc[2029, "allowance_price"] == pytest.approx(50.0, abs=1e-6)
+    assert annual_without.loc[2029, "p_co2"] == pytest.approx(50.0, abs=1e-6)
 
     policy_floor = [
         {
@@ -259,8 +259,8 @@ def test_toggles_disable_features(monkeypatch: pytest.MonkeyPatch):
     annual_with_floor = with_floor.annual.set_index("year")
     annual_without_floor = without_floor.annual.set_index("year")
 
-    assert annual_with_floor.loc[2030, "allowance_price"] == pytest.approx(20.0, abs=1e-6)
-    assert annual_without_floor.loc[2030, "allowance_price"] == pytest.approx(10.0, abs=1e-6)
+    assert annual_with_floor.loc[2030, "p_co2"] == pytest.approx(20.0, abs=1e-6)
+    assert annual_without_floor.loc[2030, "p_co2"] == pytest.approx(10.0, abs=1e-6)
     assert annual_with_floor.loc[2030, "allowances_minted"] == pytest.approx(120.0)
     assert annual_without_floor.loc[2030, "allowances_minted"] == pytest.approx(120.0)
 
@@ -296,7 +296,7 @@ def test_supply_disabled_returns_baseline(monkeypatch: pytest.MonkeyPatch):
     annual = outputs.annual.set_index("year")
     row = annual.loc[2031]
 
-    assert row["allowance_price"] == pytest.approx(0.0, abs=1e-6)
+    assert row["p_co2"] == pytest.approx(0.0, abs=1e-6)
     assert row["allowances_minted"] == pytest.approx(150.0)
     assert row["allowances_available"] == pytest.approx(150.0)
     assert row["allowances_minted"] == pytest.approx(row["emissions_tons"])


### PR DESCRIPTION
## Summary
- rename the annual engine output columns to the agreed schema (`p_co2`, `p_co2_all`, `p_co2_exc`, `p_co2_eff`, `surrender`) and update GUI handling
- update end-to-end, GUI, carbon-disabled, and policy supply tests plus add a CSV schema regression to cover the new column order
- ensure GUI banking logic picks up the configured initial bank when recomputing running balances

## Testing
- pytest tests/test_engine_end_to_end.py tests/test_gui_backend.py tests/test_carbon_disabled.py tests/test_policy_supply.py


------
https://chatgpt.com/codex/tasks/task_e_68d6e537899483279f5738784ebac083