### PR TITLE
Ensure carbon policy applies reserve price before CCR triggers

### DIFF
--- a/tests/test_carbon_policy_function.py
+++ b/tests/test_carbon_policy_function.py
@@ -79,3 +79,22 @@ def test_apply_carbon_policy_accepts_price_alias(base_config: dict[str, float | 
 
     assert result["ccr1_issued"] == pytest.approx(10.0)
     assert result["ccr2_issued"] == pytest.approx(20.0)
+
+
+def test_apply_carbon_policy_enforces_reserve_price(base_config: dict[str, float | bool]) -> None:
+    base_config["reserve_price"] = {2025: 42.0}
+    state = {
+        "year": 2025,
+        "emissions": 90.0,
+        "allowances": 100.0,
+        "price": 10.0,
+        "bank_balance": 0.0,
+    }
+
+    result = apply_carbon_policy(state, base_config)
+
+    assert result["price"] == pytest.approx(42.0)
+    assert result["ccr1_issued"] == pytest.approx(10.0)
+    assert result["ccr2_issued"] == pytest.approx(0.0)
+    assert result["allowances_minted"] == pytest.approx(110.0)
+    assert result["shortage"] is False


### PR DESCRIPTION
## Summary
- resolve reserve price values from carbon policy configurations, including year-specific schedules
- apply the reserve price floor before evaluating CCR triggers to keep pricing logic consistent
- cover reserve price behavior with a dedicated unit test for apply_carbon_policy

## Testing
- pytest tests/test_carbon_policy_function.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e51faff88327b3636c796c23073d