### PR TITLE
Align year range handling across GUI and engine

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -1093,9 +1093,10 @@ def _build_engine_outputs(
 
     for period in years:
         summary_raw = raw_results.get(period)
-        if summary_raw is None:
-            continue
-        summary = dict(summary_raw)
+        if isinstance(summary_raw, Mapping):
+            summary = dict(summary_raw)
+        else:
+            summary = {}
         price = float(summary.get("p_co2", 0.0))
         exogenous_component = float(summary.get("p_co2_exogenous", 0.0))
         dispatch_result = summary.pop("_dispatch_result", None)
@@ -1840,5 +1841,7 @@ def run_end_to_end_from_frames(
                 payload['iterations'] = 0
             progress_cb('year_complete', payload)
 
-    ordered_years = [period for period in years_sequence if period in results]
+    ordered_years = list(years_sequence)
+    for period in ordered_years:
+        results.setdefault(period, {})
     return _build_engine_outputs(ordered_years, results, dispatch_solver, policy)

--- a/gui/app.py
+++ b/gui/app.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import os
 import tempfile
+from datetime import date
 from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -1453,12 +1454,22 @@ def _render_general_config_section(
         )
 
     candidate_years = _years_from_config(base_config)
+    current_year = date.today().year
     if candidate_years:
         year_min = min(candidate_years)
         year_max = max(candidate_years)
     else:
-        year_min = int(base_config.get("start_year", 2025) or 2025)
-        year_max = int(base_config.get("end_year", year_min) or year_min)
+        try:
+            year_min = int(base_config.get("start_year", current_year) or current_year)
+        except (TypeError, ValueError):
+            year_min = int(current_year)
+        try:
+            fallback_end = base_config.get("end_year", year_min + 1)
+            year_max = int(fallback_end) if fallback_end not in (None, "") else year_min + 1
+        except (TypeError, ValueError):
+            year_max = year_min + 1
+        if year_max <= year_min:
+            year_max = year_min + 1
     if year_min > year_max:
         year_min, year_max = year_max, year_min
 
@@ -1468,24 +1479,51 @@ def _render_general_config_section(
         except (TypeError, ValueError):
             return int(fallback)
 
-    start_default = max(year_min, min(year_max, _coerce_year(base_config.get("start_year", year_min), year_min)))
-    end_default = max(year_min, min(year_max, _coerce_year(base_config.get("end_year", year_max), year_max)))
-    if start_default > end_default:
-        start_default, end_default = end_default, start_default
+    start_default = max(
+        year_min,
+        min(year_max, _coerce_year(base_config.get("start_year", year_min), year_min)),
+    )
+    end_default = max(
+        year_min,
+        min(year_max, _coerce_year(base_config.get("end_year", year_max), year_max)),
+    )
+    if end_default <= start_default:
+        end_default = start_default + 1
 
-    slider_min_default = 2025
-    slider_max_default = 2050
+    slider_min_dynamic = min(year_min, start_default, end_default)
+    slider_max_dynamic = max(year_max, start_default, end_default)
+    if slider_min_dynamic == slider_max_dynamic:
+        slider_min_dynamic -= 1
+        slider_max_dynamic += 1
+    if slider_min_dynamic >= slider_max_dynamic:
+        slider_max_dynamic = slider_min_dynamic + 1
+    slider_min_dynamic = int(slider_min_dynamic)
+    slider_max_dynamic = int(slider_max_dynamic)
     slider_min_value, slider_max_value = container.slider(
         "Simulation Years",
-        min_value=slider_min_default,
-        max_value=slider_max_default,
-        value=(start_default, end_default),
+        min_value=slider_min_dynamic,
+        max_value=slider_max_dynamic,
+        value=(
+            max(slider_min_dynamic, min(start_default, slider_max_dynamic - 1)),
+            max(
+                max(slider_min_dynamic + 1, min(end_default, slider_max_dynamic)),
+                slider_min_dynamic + 1,
+            ),
+        ),
         step=1,
         key="general_year_slider",
     )
 
-    start_year = slider_min_value
-    end_year = slider_max_value
+    start_year = int(slider_min_value)
+    end_year = int(slider_max_value)
+
+    if st is not None:
+        st.session_state["start_year_slider"] = start_year
+        st.session_state["end_year_slider"] = end_year
+
+    invalid_year_range = start_year >= end_year
+    if invalid_year_range:
+        container.error("End year must be greater than start year.")
 
     region_options = _regions_from_config(base_config)
     default_region_values = list(range(1, 26))
@@ -1644,10 +1682,19 @@ def _render_general_config_section(
     try:
         selected_years = _select_years(candidate_years, start_year, end_year)
     except Exception:
-        step = 1 if end_year >= start_year else -1
-        selected_years = list(range(start_year, end_year + step, step))
-    if not selected_years:
-        selected_years = [start_year]
+        selected_years = []
+    if selected_years:
+        try:
+            selected_min = min(int(year) for year in selected_years)
+            selected_max = max(int(year) for year in selected_years)
+        except ValueError:
+            selected_years = []
+        else:
+            selected_years = list(range(selected_min, selected_max + 1))
+    elif not invalid_year_range:
+        selected_years = list(range(start_year, end_year + 1))
+    else:
+        selected_years = []
 
     return GeneralConfigResult(
         config_label=config_label,
@@ -3753,7 +3800,7 @@ def _render_demand_controls(
     if not target_years and not demand_default.empty:
         target_years = sorted({int(year) for year in demand_default["year"].unique()})
     if not target_years:
-        target_years = [2025]
+        target_years = [int(date.today().year)]
 
     use_manual = st.checkbox("Create demand profile with controls", value=False, key="demand_manual_toggle")
     if use_manual:
@@ -4486,72 +4533,7 @@ def run_policy_simulation(
         }
     )
 
-    merged_modules["carbon_price"] = price_cfg.as_dict()
-
-    raw_run_years = []
-    try:
-        raw_run_years = [int(year) for year in years]
-    except Exception:
-        raw_run_years = []
-    run_years_sorted = sorted(dict.fromkeys(raw_run_years))
-
-    provided_price_schedule: dict[int, float] = {}
-    if isinstance(price_cfg.schedule, Mapping):
-        for year, value in price_cfg.schedule.items():
-            try:
-                provided_price_schedule[int(year)] = float(value)
-            except (TypeError, ValueError):
-                continue
-
-    price_schedule_map: dict[int, float] = {}
-    if price_cfg.active:
-        if run_years_sorted:
-            start_year = run_years_sorted[0]
-            end_year = run_years_sorted[-1]
-        elif provided_price_schedule:
-            start_year = min(provided_price_schedule)
-            end_year = max(provided_price_schedule)
-        else:
-            start_year = end_year = None
-
-        if start_year is not None and end_year is not None:
-            base_year = min(provided_price_schedule) if provided_price_schedule else start_year
-            base_price = provided_price_schedule.get(base_year, price_cfg.price_per_ton)
-            try:
-                base_price_float = float(base_price)
-            except (TypeError, ValueError):
-                base_price_float = 0.0
-
-            growth_pct = float(price_cfg.escalator_pct)
-
-            if base_year is not None and base_year != start_year:
-                ratio = 1.0 + (growth_pct or 0.0) / 100.0
-                try:
-                    steps = base_year - start_year
-                    if ratio != 0.0:
-                        base_price_float = base_price_float / (ratio ** steps)
-                except OverflowError:
-                    base_price_float = 0.0
-
-            generated_schedule = _build_price_schedule(
-                start_year,
-                end_year,
-                base_price_float,
-                growth_pct,
-            )
-
-            if run_years_sorted:
-                generated_schedule = {
-                    year: generated_schedule.get(year, base_price_float)
-                    for year in run_years_sorted
-                }
-
-            for year, value in provided_price_schedule.items():
-                generated_schedule[int(year)] = float(value)
-
-            price_schedule_map = dict(sorted(generated_schedule.items()))
-
-    price_active = bool(price_cfg.active and price_schedule_map)
+    # Carbon price schedule will be populated after years are finalised below
 
     cap_schedule_map: dict[int, float] = {}
     if isinstance(carbon_cap_schedule, Mapping):
@@ -4658,12 +4640,97 @@ def run_policy_simulation(
         if fallback_year is not None:
             years = [int(fallback_year)]
         else:
-            years = [2025]
+            years = [int(date.today().year)]
 
-    years = sorted({int(year) for year in years})
+    normalized_years = sorted({int(year) for year in years})
+    if normalized_years:
+        year_start = normalized_years[0]
+        year_end = normalized_years[-1]
+        years = list(range(year_start, year_end + 1))
+    else:
+        current_year = int(date.today().year)
+        years = [current_year]
+
     config["years"] = list(years)
     config["start_year"] = int(years[0])
     config["end_year"] = int(years[-1])
+
+    provided_price_schedule: dict[int, float] = {}
+    if isinstance(price_cfg.schedule, Mapping):
+        for year, value in price_cfg.schedule.items():
+            try:
+                provided_price_schedule[int(year)] = float(value)
+            except (TypeError, ValueError):
+                continue
+
+    price_schedule_map: dict[int, float] = {}
+    if price_cfg.enabled and years:
+        run_years_sorted = sorted(dict.fromkeys(int(year) for year in years))
+        if run_years_sorted:
+            start_year_schedule = run_years_sorted[0]
+            end_year_schedule = run_years_sorted[-1]
+            base_year = (
+                min(provided_price_schedule)
+                if provided_price_schedule
+                else start_year_schedule
+            )
+            base_price = provided_price_schedule.get(base_year, price_cfg.price_per_ton)
+            try:
+                base_price_float = float(base_price)
+            except (TypeError, ValueError):
+                base_price_float = 0.0
+
+            growth_pct = float(price_cfg.escalator_pct)
+            if base_year is not None and base_year != start_year_schedule:
+                ratio = 1.0 + (growth_pct or 0.0) / 100.0
+                try:
+                    steps = base_year - start_year_schedule
+                    if ratio != 0.0:
+                        base_price_float = base_price_float / (ratio ** steps)
+                except OverflowError:
+                    base_price_float = 0.0
+
+            generated_schedule = _build_price_schedule(
+                start_year_schedule,
+                end_year_schedule,
+                base_price_float,
+                growth_pct,
+            )
+
+            combined_schedule = dict(sorted(generated_schedule.items()))
+            for year, value in provided_price_schedule.items():
+                try:
+                    combined_schedule[int(year)] = float(value)
+                except (TypeError, ValueError):
+                    continue
+
+            combined_items = sorted(combined_schedule.items())
+            if combined_items:
+                first_price = float(combined_items[0][1])
+            else:
+                first_price = float(base_price_float)
+            filled_schedule: dict[int, float] = {}
+            last_price: float | None = None
+            index = 0
+            total_items = len(combined_items)
+
+            for year in run_years_sorted:
+                while index < total_items and combined_items[index][0] <= year:
+                    last_price = float(combined_items[index][1])
+                    index += 1
+                if last_price is None:
+                    last_price = first_price
+                filled_schedule[year] = float(last_price)
+
+            price_schedule_map = filled_schedule
+
+    price_active = bool(price_cfg.enabled and price_schedule_map)
+    if price_active:
+        price_cfg.schedule = dict(price_schedule_map)
+    else:
+        price_cfg.schedule = {}
+
+    merged_modules["carbon_price"] = price_cfg.as_dict()
 
     carbon_price_for_frames: Mapping[int, float] | None = (
         price_schedule_map if price_active else None
@@ -5727,8 +5794,12 @@ def main() -> None:
     selected_years: list[int] = []
     candidate_years: list[int] = []
     frames_for_run: FramesType | None = None
-    start_year_val = int(run_config.get('start_year', 2025)) if run_config else 2025
-    end_year_val = int(run_config.get('end_year', start_year_val)) if run_config else start_year_val
+    current_year = date.today().year
+    start_year_val = int(run_config.get('start_year', current_year)) if run_config else int(current_year)
+    default_end_year = start_year_val + 1
+    end_year_val = int(run_config.get('end_year', default_end_year)) if run_config else int(default_end_year)
+    if end_year_val <= start_year_val:
+        end_year_val = start_year_val + 1
 
     carbon_settings = CarbonModuleSettings(
         enabled=False,
@@ -5810,6 +5881,11 @@ def main() -> None:
             end_year_val = general_result.end_year
             selected_years = general_result.selected_years
 
+            if start_year_val >= end_year_val:
+                year_error = "Simulation end year must be greater than start year."
+                if year_error not in module_errors:
+                    module_errors.append(year_error)
+
             # -------- Carbon --------
             carbon_label, carbon_expanded = SIDEBAR_SECTIONS[1]
             carbon_expander = st.expander(carbon_label, expanded=carbon_expanded)
@@ -5824,7 +5900,8 @@ def main() -> None:
             # Prepare default frames (defensive)
             try:
                 frames_for_run = _build_default_frames(
-                    selected_years or [start_year_val],
+                    selected_years
+                    or list(range(int(start_year_val), int(end_year_val) + 1)),
                     carbon_policy_enabled=bool(
                         carbon_settings.enabled and not carbon_settings.price_enabled
                     ),
@@ -5908,19 +5985,47 @@ def main() -> None:
             run_clicked = st.button("Run Model", type="primary", use_container_width=True)
 
     # Finalize selected years defensively
+    if st is not None:
+        try:
+            start_year_state = int(st.session_state.get("start_year_slider", start_year_val))
+        except (TypeError, ValueError):
+            start_year_state = int(start_year_val)
+        try:
+            end_year_state = int(st.session_state.get("end_year_slider", end_year_val))
+        except (TypeError, ValueError):
+            end_year_state = int(end_year_val)
+        start_year_val = start_year_state
+        end_year_val = end_year_state
+
+    default_years: list[int] = []
+    if start_year_val < end_year_val:
+        default_years = list(range(int(start_year_val), int(end_year_val) + 1))
+    elif start_year_val == end_year_val:
+        default_years = [int(start_year_val)]
+
     try:
         selected_years = _select_years(candidate_years, start_year_val, end_year_val)
     except Exception:
-        selected_years = selected_years or []
-    if not selected_years:
-        step = 1 if end_year_val >= start_year_val else -1
-        selected_years = list(range(start_year_val, end_year_val + step, step))
+        selected_years = []
+
+    if selected_years:
+        try:
+            selected_min = min(int(year) for year in selected_years)
+            selected_max = max(int(year) for year in selected_years)
+        except ValueError:
+            selected_years = []
+        else:
+            selected_years = list(range(selected_min, selected_max + 1))
+    else:
+        selected_years = list(default_years)
 
     # Ensure frames if earlier failed
     if frames_for_run is None:
         try:
             frames_for_run = _build_default_frames(
-                selected_years or [start_year_val],
+                selected_years
+                or default_years
+                or [int(start_year_val)],
                 carbon_policy_enabled=bool(
                     carbon_settings.enabled and not carbon_settings.price_enabled
                 ),


### PR DESCRIPTION
## Summary
- make the general year slider dynamic, persist its values in session state, and surface an error when the start year is not before the end year
- normalize selected years and defaults so downstream modules and payloads operate on a contiguous annual range sourced from the slider
- forward-fill explicit or generated carbon price schedules across all modeled years and ensure the engine produces records for each simulated year

## Testing
- pytest tests/test_gui_backend.py -k year --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68d6ec16bbc88327ac03866777a5c750