### PR TITLE
Hide progress log after run completes

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -651,7 +651,9 @@ def _sync_progress_ui(
     else:
         progress_placeholder.progress(percent)
 
-    if state.log:
+    if state.stage == "complete":
+        log_placeholder.caption("Progress updates will appear here during the run.")
+    elif state.log:
         log_placeholder.markdown(_progress_log_markdown(state.log))
     else:
         log_placeholder.caption("Progress updates will appear here during the run.")


### PR DESCRIPTION
## Summary
- prevent completed runs from leaving their detailed progress log visible
- keep the log area ready for the next execution after the progress bar reaches 100%

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f0c3171c8327b9897ca0f60536e9