### PR TITLE
Align emissions region dropdown with metadata

### DIFF
--- a/tests/test_outputs_visualization.py
+++ b/tests/test_outputs_visualization.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from gui.outputs_visualization import region_selection_options
+from gui.region_metadata import DEFAULT_REGION_METADATA
+
+
+def test_region_selection_options_uses_metadata_labels():
+    df = pd.DataFrame(
+        {
+            "region_canonical": [1, 2, pd.NA, 2],
+            "region_label": ["custom", "labels", pd.NA, "labels"],
+        }
+    )
+
+    options = region_selection_options(df)
+
+    expected = [
+        (DEFAULT_REGION_METADATA[1].label, 1),
+        (DEFAULT_REGION_METADATA[2].label, 2),
+    ]
+    assert options == expected
+
+
+def test_region_selection_options_falls_back_to_metadata_for_default_entries():
+    df = pd.DataFrame(
+        {
+            "region_canonical": ["default", "default"],
+            "region_label": ["default", "default"],
+        }
+    )
+
+    options = region_selection_options(df)
+
+    assert len(options) == len(DEFAULT_REGION_METADATA)
+    assert {value for _, value in options} == set(DEFAULT_REGION_METADATA)
+    assert all(label != "default" for label, _ in options)


### PR DESCRIPTION
## Summary
- ensure the emissions region dropdown labels use the canonical metadata definitions
- skip placeholder "default" entries and fall back to all default regions when no valid options exist
- add unit tests covering the updated dropdown option logic

## Testing
- `pytest tests/test_outputs_visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6f41ff334832793c72eaa7c89d5d9