### PR TITLE
Ensure regional emissions data is cached for UI display

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -5541,6 +5541,21 @@ def run_policy_simulation(
         if isinstance(frame, pd.DataFrame):
             result[key] = frame
 
+    processed_emissions = load_emissions_data(result)
+    if isinstance(processed_emissions, pd.DataFrame) and not processed_emissions.empty:
+        result['emissions_by_region'] = processed_emissions
+        csv_files = result.get('csv_files')
+        if isinstance(csv_files, Mapping):
+            try:
+                updated_csv = dict(csv_files)
+                updated_csv['emissions_by_region.csv'] = processed_emissions.to_csv(
+                    index=False
+                ).encode('utf-8')
+            except Exception:  # pragma: no cover - defensive guard
+                pass
+            else:
+                result['csv_files'] = updated_csv
+
     return result
 
     # Carbon price config

--- a/tests/test_gui_backend.py
+++ b/tests/test_gui_backend.py
@@ -409,6 +409,9 @@ def test_render_results_carbon_price_hides_allowance_columns(monkeypatch):
         def download_button(self, *args, **kwargs):
             return None
 
+        def multiselect(self, label, options, *, default=None, key=None):
+            return list(default or [])
+
     dummy_st = DummyStreamlit()
     monkeypatch.setattr(gui_app, "st", dummy_st)
 
@@ -521,7 +524,12 @@ def test_backend_handles_renamed_engine_outputs(monkeypatch):
     )
 
     pd.testing.assert_frame_equal(result["annual"], annual)
-    pd.testing.assert_frame_equal(result["emissions_by_region"], emissions)
+    emissions_result = result["emissions_by_region"]
+    assert {"region_canonical", "region_label"}.issubset(emissions_result.columns)
+    pd.testing.assert_frame_equal(
+        emissions_result[emissions.columns],
+        emissions,
+    )
     pd.testing.assert_frame_equal(result["price_by_region"], prices)
     pd.testing.assert_frame_equal(result["flows"], flows)
 
@@ -583,7 +591,12 @@ def test_backend_handles_legacy_runner_without_deep_kw(monkeypatch):
     assert "error" not in result
     assert called.get("executed") is True
     pd.testing.assert_frame_equal(result["annual"], annual)
-    pd.testing.assert_frame_equal(result["emissions_by_region"], emissions)
+    emissions_result = result["emissions_by_region"]
+    assert {"region_canonical", "region_label"}.issubset(emissions_result.columns)
+    pd.testing.assert_frame_equal(
+        emissions_result[emissions.columns],
+        emissions,
+    )
     pd.testing.assert_frame_equal(result["price_by_region"], prices)
     pd.testing.assert_frame_equal(result["flows"], flows)
 


### PR DESCRIPTION
## Summary
- post-process engine results to cache canonicalised regional emissions data for the latest run
- update cached CSV bytes when regional emissions are available so downloads match the UI
- adjust GUI backend tests to expect the enriched emissions table and exercise the emissions tab controls

## Testing
- pytest tests/test_gui_backend.py


------
https://chatgpt.com/codex/tasks/task_e_68d6f6b3ed30832781a0bee4b9a25885