### PR TITLE
Add cap-mode price solver and tests

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,1 +1,21 @@
 """Simulation engine utilities."""
+
+from .cap_mode import (
+    CapInfeasibleError,
+    CapParams,
+    CapRunResult,
+    align_series,
+    dispatch_min_cost,
+    run_cap_mode,
+    solve_price_for_year,
+)
+
+__all__ = [
+    "CapInfeasibleError",
+    "CapParams",
+    "CapRunResult",
+    "align_series",
+    "dispatch_min_cost",
+    "run_cap_mode",
+    "solve_price_for_year",
+]

--- a/engine/cap_mode.py
+++ b/engine/cap_mode.py
@@ -1,0 +1,324 @@
+"""Allowance market clearing under an endogenous cap price."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Protocol
+
+import numpy as np
+import pandas as pd
+
+
+LOGGER = logging.getLogger(__name__)
+
+P_MAX = 2_000.0
+PRICE_TOL = 1e-3
+MAX_ITERS = 60
+_SHORTAGE_TOL = 1e-6
+
+
+class _DispatchFrameLike(Protocol):
+    base_costs: pd.Series
+    emission_rates: pd.Series
+    capacities: pd.Series
+
+
+@dataclass(frozen=True)
+class CapParams:
+    """Container describing allowance supply schedules for cap mode."""
+
+    budgets: Mapping[int, float]
+    reserve: Mapping[int, float]
+    ccr1_trigger: Mapping[int, float]
+    ccr1_amount: Mapping[int, float]
+    ccr2_trigger: Mapping[int, float]
+    ccr2_amount: Mapping[int, float]
+    banking: bool = True
+
+
+@dataclass(frozen=True)
+class CapRunResult:
+    """Structured output from :func:`run_cap_mode`."""
+
+    table: pd.DataFrame
+    diagnostics: list[dict[str, Any]]
+
+    def __post_init__(self) -> None:  # pragma: no cover - defensive
+        if not isinstance(self.table, pd.DataFrame):
+            raise TypeError("table must be a pandas DataFrame")
+
+    # Delegate convenient accessors to the underlying DataFrame so callers
+    # can use ``result['p_co2']`` directly in tests and plotting utilities.
+    def __getitem__(self, key: Any) -> Any:  # pragma: no cover - thin wrapper
+        return self.table.__getitem__(key)
+
+    def __iter__(self):  # pragma: no cover - thin wrapper
+        return iter(self.table)
+
+    def __len__(self) -> int:  # pragma: no cover - thin wrapper
+        return len(self.table)
+
+    def to_records(self) -> list[dict[str, Any]]:
+        """Return the output table as a list of dictionaries."""
+
+        return self.table.to_dict(orient="records")
+
+
+def align_series(
+    series: Mapping[int, float] | None, years: Iterable[int], fill: float = 0.0
+) -> dict[int, float]:
+    """Return ``series`` aligned to ``years`` carrying the last value forward."""
+
+    years_list = [int(year) for year in years]
+    if not series:
+        return {year: float(fill) for year in years_list}
+
+    normalized: dict[int, float] = {}
+    last: float | None = None
+    for year in sorted(years_list):
+        if year in series:
+            last = float(series[year])
+        if last is None:
+            last = float(fill)
+        normalized[year] = float(last)
+    return normalized
+
+
+def dispatch_min_cost(
+    frames_for_year: _DispatchFrameLike, mc: pd.Series, demand_mwh: float
+) -> pd.Series:
+    """Return the minimum-cost dispatch by technology for ``demand_mwh``."""
+
+    if not isinstance(mc, pd.Series):
+        raise TypeError("marginal costs must be provided as a pandas Series")
+
+    try:
+        capacities = frames_for_year.capacities
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise AttributeError("frames_for_year must define a 'capacities' Series") from exc
+
+    if not isinstance(capacities, pd.Series):
+        capacities = pd.Series(capacities)
+
+    demand = float(max(demand_mwh, 0.0))
+
+    capacity_aligned = capacities.reindex(mc.index).fillna(0.0)
+    ordered = mc.sort_values(kind="mergesort")
+
+    dispatch = pd.Series(0.0, index=ordered.index, dtype=float)
+    remaining = demand
+
+    for tech in ordered.index:
+        cap = float(capacity_aligned.get(tech, 0.0))
+        if cap <= 0.0:
+            continue
+        allocation = cap if remaining >= cap else remaining
+        if allocation > 0.0:
+            dispatch.at[tech] = allocation
+            remaining -= allocation
+        if remaining <= _SHORTAGE_TOL:
+            remaining = 0.0
+            break
+
+    if remaining > _SHORTAGE_TOL:
+        LOGGER.debug(
+            "Dispatch shortage encountered: demand=%s, supplied=%s",
+            demand,
+            demand - remaining,
+        )
+
+    return dispatch.reindex(mc.index, fill_value=0.0)
+
+
+def _supply_y(y: int, p: float, par: CapParams) -> float:
+    reserve = float(par.reserve.get(y, 0.0))
+    price = max(float(p), reserve)
+    rel1 = 0.0
+    rel2 = 0.0
+    ccr1_trigger = float(par.ccr1_trigger.get(y, float("inf")))
+    ccr2_trigger = float(par.ccr2_trigger.get(y, float("inf")))
+    if price >= ccr1_trigger:
+        rel1 = float(par.ccr1_amount.get(y, 0.0))
+    if price >= ccr2_trigger:
+        rel2 = float(par.ccr2_amount.get(y, 0.0))
+    return float(par.budgets.get(y, 0.0)) + rel1 + rel2
+
+
+def _emissions_y(
+    y: int,
+    p: float,
+    frames_for_year: _DispatchFrameLike,
+    demand_mwh: float,
+) -> float:
+    base_costs = frames_for_year.base_costs
+    emission_rates = frames_for_year.emission_rates
+    if not isinstance(base_costs, pd.Series) or not isinstance(emission_rates, pd.Series):
+        raise TypeError("frames_for_year must provide base_costs and emission_rates as Series")
+
+    marginal_cost = base_costs + emission_rates * float(p)
+    generation = dispatch_min_cost(frames_for_year, marginal_cost, demand_mwh)
+    emissions = (emission_rates.reindex(generation.index, fill_value=0.0) * generation).sum()
+
+    if p > 0.0:
+        marginal_without_price = base_costs
+        if np.allclose(marginal_cost.values, marginal_without_price.values):
+            LOGGER.warning("Dispatch cost not using carbon price.")
+
+    return float(emissions)
+
+
+class CapInfeasibleError(RuntimeError):
+    """Error raised when the cap cannot be met within the price search range."""
+
+
+def solve_price_for_year(
+    y: int,
+    bank_prev: float,
+    frames_for_year: _DispatchFrameLike,
+    demand_mwh: float,
+    par: CapParams,
+) -> tuple[float, float, int, float]:
+    """Solve for the clearing price ``p`` in year ``y`` returning price and bank."""
+
+    reserve = float(par.reserve.get(y, 0.0))
+    p_lo = reserve
+    p_hi = P_MAX
+
+    def excess(price: float) -> float:
+        supply = _supply_y(y, price, par)
+        emissions = _emissions_y(y, price, frames_for_year, demand_mwh)
+        available = supply + (bank_prev if par.banking else 0.0)
+        return available - emissions
+
+    excess_lo = excess(p_lo)
+    if excess_lo < 0.0:
+        trial = max(p_lo, 1.0)
+        while trial < P_MAX and excess(trial) < 0.0:
+            trial = min(trial * 2.0, P_MAX)
+        p_hi = trial
+        if p_hi >= P_MAX and excess(p_hi) < 0.0:
+            raise CapInfeasibleError("Cap infeasible at P_MAX.")
+    else:
+        p_hi = p_lo
+
+    iterations = 0
+    while iterations < MAX_ITERS and abs(p_hi - p_lo) > PRICE_TOL:
+        p_mid = 0.5 * (p_lo + p_hi)
+        if excess(p_mid) >= 0.0:
+            p_hi = p_mid
+        else:
+            p_lo = p_mid
+        iterations += 1
+
+    p_raw = p_hi
+    clearing_price = max(p_raw, reserve)
+    supply = _supply_y(y, clearing_price, par)
+    emissions = _emissions_y(y, clearing_price, frames_for_year, demand_mwh)
+    available = supply + (bank_prev if par.banking else 0.0)
+    bank_new = float(max(available - emissions, 0.0)) if par.banking else 0.0
+
+    return float(clearing_price), float(bank_new), iterations, float(p_raw)
+
+
+def run_cap_mode(
+    run_years: Iterable[int],
+    frames_by_year: Mapping[int, _DispatchFrameLike],
+    demand_sched: Mapping[int, float],
+    par: CapParams,
+    bank0: float,
+) -> CapRunResult:
+    """Execute the allowance market clearing for ``run_years`` under cap mode."""
+
+    ordered_years = [int(year) for year in run_years]
+    bank = float(bank0 if par.banking else 0.0)
+    records: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+
+    for year in ordered_years:
+        frames_for_year = frames_by_year[year]
+        demand_value = float(demand_sched[year])
+        bank_in = bank
+        try:
+            price, bank, iterations, price_raw = solve_price_for_year(
+                year,
+                bank,
+                frames_for_year,
+                demand_value,
+                par,
+            )
+        except CapInfeasibleError:
+            LOGGER.error("Cap infeasible at P_MAX for year %s", year)
+            raise
+
+        supply = _supply_y(year, price, par)
+        emissions = _emissions_y(year, price, frames_for_year, demand_value)
+        available = supply + (bank_in if par.banking else 0.0)
+        shortage = emissions > available + 1e-6
+
+        records.append(
+            {
+                "year": year,
+                "p_co2": round(price, 6),
+                "iterations": int(iterations),
+                "emissions_tons": round(emissions, 3),
+                "allowances_total": round(supply, 3),
+                "available_allowances": round(available, 3),
+                "bank": round(bank, 3),
+                "shortage_flag": bool(shortage),
+            }
+        )
+
+        diagnostics.append(
+            {
+                "year": year,
+                "p_raw": price_raw,
+                "reserve": float(par.reserve.get(year, 0.0)),
+                "ccr1_trig": float(par.ccr1_trigger.get(year, float("inf"))),
+                "ccr2_trig": float(par.ccr2_trigger.get(year, float("inf"))),
+                "ccr_release_total": float(supply - float(par.budgets.get(year, 0.0))),
+                "budget": float(par.budgets.get(year, 0.0)),
+                "demand_mwh": demand_value,
+                "emissions": emissions,
+                "bank_in": bank_in if par.banking else 0.0,
+                "bank_out": bank if par.banking else 0.0,
+                "shortage": bool(shortage),
+            }
+        )
+
+        LOGGER.debug(
+            "Year %s cleared: price=%s, supply=%s, emissions=%s, bank_in=%s, bank_out=%s",
+            year,
+            price,
+            supply,
+            emissions,
+            bank_in,
+            bank,
+        )
+
+    df = pd.DataFrame(records, columns=[
+        "year",
+        "p_co2",
+        "iterations",
+        "emissions_tons",
+        "allowances_total",
+        "available_allowances",
+        "bank",
+        "shortage_flag",
+    ])
+    if not df.empty:
+        df = df.set_index("year", drop=False)
+
+    return CapRunResult(df, diagnostics)
+
+
+__all__ = [
+    "CapParams",
+    "CapRunResult",
+    "CapInfeasibleError",
+    "align_series",
+    "dispatch_min_cost",
+    "run_cap_mode",
+    "solve_price_for_year",
+]
+

--- a/tests/test_cap_mode.py
+++ b/tests/test_cap_mode.py
@@ -1,0 +1,128 @@
+"""Unit tests for the endogenous cap allowance pricing engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from engine.cap_mode import CapParams, align_series, run_cap_mode
+
+
+@dataclass
+class SimpleDispatchFrame:
+    """Minimal dispatch frame used to exercise price responsiveness."""
+
+    base_costs: pd.Series
+    emission_rates: pd.Series
+    capacities: pd.Series
+
+
+BASE_COSTS = pd.Series(
+    {
+        "coal1": 18.0,
+        "coal2": 22.0,
+        "gas1": 28.0,
+        "gas2": 32.0,
+        "wind": 38.0,
+    }
+)
+EMISSION_RATES = pd.Series(
+    {
+        "coal1": 1.0,
+        "coal2": 1.0,
+        "gas1": 0.5,
+        "gas2": 0.5,
+        "wind": 0.0,
+    }
+)
+CAPACITIES = pd.Series(
+    {
+        "coal1": 30.0,
+        "coal2": 30.0,
+        "gas1": 30.0,
+        "gas2": 30.0,
+        "wind": 40.0,
+    }
+)
+
+
+def _build_frames(years: list[int]) -> dict[int, SimpleDispatchFrame]:
+    frames: dict[int, SimpleDispatchFrame] = {}
+    for year in years:
+        frames[year] = SimpleDispatchFrame(
+            base_costs=BASE_COSTS,
+            emission_rates=EMISSION_RATES,
+            capacities=CAPACITIES,
+        )
+    return frames
+
+
+def run_case(
+    *,
+    cap: float = 70.0,
+    demand: float = 1.0,
+    banking: bool = True,
+    bank0: float = 0.0,
+) -> tuple[pd.DataFrame, list[dict]]:
+    years = list(range(2025, 2031))
+    frames = _build_frames(years)
+
+    demand_base = {year: 120.0 * demand for year in years}
+    demand_sched = align_series(demand_base, years, 120.0)
+
+    budgets = align_series({years[0]: cap}, years, cap)
+    reserve = align_series({years[0]: 12.0}, years, 12.0)
+    ccr1_trigger = align_series({2030: 15.0}, years, float("inf"))
+    ccr1_amount = align_series({2030: 15.0}, years, 0.0)
+    ccr2_trigger = align_series({}, years, float("inf"))
+    ccr2_amount = align_series({}, years, 0.0)
+
+    params = CapParams(
+        budgets=budgets,
+        reserve=reserve,
+        ccr1_trigger=ccr1_trigger,
+        ccr1_amount=ccr1_amount,
+        ccr2_trigger=ccr2_trigger,
+        ccr2_amount=ccr2_amount,
+        banking=banking,
+    )
+
+    result = run_cap_mode(years, frames, demand_sched, params, bank0)
+    return result.table, result.diagnostics
+
+
+def test_cap_responsiveness() -> None:
+    table_lo, _ = run_case(cap=70.0)
+    table_hi, _ = run_case(cap=60.0)
+    assert table_hi.loc[2028, "p_co2"] > table_lo.loc[2028, "p_co2"]
+
+
+def test_demand_responsiveness() -> None:
+    table_base, _ = run_case(cap=65.0, demand=1.0)
+    table_high, _ = run_case(cap=65.0, demand=1.1)
+    assert table_high.loc[2027, "p_co2"] > table_base.loc[2027, "p_co2"]
+
+
+def test_reserve_floor_binds() -> None:
+    table, _ = run_case(cap=80.0)
+    assert table.loc[2025, "p_co2"] >= 12.0
+
+
+def test_ccr_triggers_when_price_crosses() -> None:
+    table, _ = run_case(cap=55.0)
+    allowances_total = table.loc[2030, "allowances_total"]
+    assert allowances_total >= 70.0
+
+
+def test_banking_toggle_affects_price() -> None:
+    table_on, _ = run_case(cap=60.0, banking=True, bank0=30.0)
+    table_off, _ = run_case(cap=60.0, banking=False, bank0=0.0)
+    assert table_on.loc[2027, "p_co2"] <= table_off.loc[2027, "p_co2"]
+
+
+def test_annual_coverage() -> None:
+    table, _ = run_case()
+    years = list(range(2025, 2031))
+    assert list(table["year"]) == years
+


### PR DESCRIPTION
## Summary
- implement an endogenous cap-mode allowance price solver with CCR, reserve floor, and banking support
- expose the new solver from the engine package and add focused unit coverage

## Testing
- pytest tests/test_cap_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68d6f93b991c83279537bc5fecbf8601