### PR TITLE
Add regional emissions aggregation and reporting

### DIFF
--- a/cli/run.py
+++ b/cli/run.py
@@ -205,6 +205,13 @@ def _write_outputs(outputs: EngineOutputs, out_dir: Path) -> None:
         flows_filename='flows.csv',
     )
 
+    summary_table = outputs.emissions_summary_table()
+    if summary_table.empty:
+        typer.secho('Regional emissions summary: no data available.', fg=typer.colors.YELLOW)
+    else:
+        typer.secho('Regional emissions summary (tons):', fg=typer.colors.BLUE)
+        typer.echo(summary_table.to_string(index=False))
+
 
 @app.command()
 def main(

--- a/dispatch/lp_single.py
+++ b/dispatch/lp_single.py
@@ -246,6 +246,10 @@ def solve(
     if not emissions_by_region:
         emissions_by_region = {_DEFAULT_REGION: 0.0}
 
+    demand_regions = {str(region) for region in demand.keys()}
+    for region in demand_regions:
+        emissions_by_region.setdefault(region, 0.0)
+
     # coverage and imports/exports (main branch)
     total_generation = float(generation.sum())
     generation_by_coverage = {"covered": 0.0, "non_covered": 0.0}


### PR DESCRIPTION
## Summary
- ensure dispatch populates zero-emission entries for demand regions and aggregate them in the engine
- expose regional emissions maps and summaries through EngineOutputs, the CLI, and GUI packaging
- extend engine tests to cover the new emissions mappings and zero-fill behaviour

## Testing
- pytest tests/test_engine_end_to_end.py
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fe8295448327aa446236b2ab641b