### PR TITLE
Add regional data integrity and dispatch scaling tests

### DIFF
--- a/gui/region_metadata.py
+++ b/gui/region_metadata.py
@@ -38,9 +38,10 @@ DEFAULT_REGION_METADATA: Mapping[int, RegionMetadata] = {
     ),
     3: RegionMetadata(
         id=3,
-        code="SPPC",
+        code="WNC",
         area="Midwest / WNCentral",
-        label="Region 3 – SPPC (Midwest / WNCentral)",
+        label="Region 3 – WNCentral aggregate (Midwest / WNCentral)",
+        aliases=("wncentral", "midwest wncentral", "wnc aggregate"),
     ),
     4: RegionMetadata(
         id=4,

--- a/tests/test_region_data_integrity.py
+++ b/tests/test_region_data_integrity.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from gui.region_metadata import DEFAULT_REGION_METADATA
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _unique_int_values(df, *columns: str) -> set[int]:
+    values: set[int] = set()
+    for column in columns:
+        if column not in df.columns:
+            continue
+        series = pd.to_numeric(df[column], errors="coerce").dropna()
+        values.update(int(value) for value in series.astype(int).tolist())
+    return values
+
+
+def test_region_metadata_is_unique_and_complete() -> None:
+    metadata = DEFAULT_REGION_METADATA
+    assert len(metadata) == 25
+
+    ids_from_keys = set(metadata.keys())
+    ids_from_values = {meta.id for meta in metadata.values()}
+    assert ids_from_keys == ids_from_values
+
+    codes = [meta.code for meta in metadata.values()]
+    assert len(codes) == len(set(codes))
+
+    labels = [meta.label for meta in metadata.values()]
+    assert len(labels) == len(set(labels))
+
+
+def test_region_ids_align_with_input_data() -> None:
+    metadata_ids = set(DEFAULT_REGION_METADATA.keys())
+
+    hydrogen_regions = pd.read_csv(
+        PROJECT_ROOT / "input" / "hydrogen" / "all_regions" / "regions.csv"
+    )
+    hydrogen_hubs = pd.read_csv(
+        PROJECT_ROOT / "input" / "hydrogen" / "all_regions" / "hubs.csv"
+    )
+
+    assert metadata_ids == _unique_int_values(hydrogen_regions, "Region")
+    assert metadata_ids == _unique_int_values(hydrogen_hubs, "region")
+
+    cem_inputs = PROJECT_ROOT / "input" / "electricity" / "cem_inputs"
+    electricity_checks = {
+        "CarbonCapGroupMap.csv": ("region",),
+        "SupplyCurve.csv": ("region",),
+        "SupplyPrice.csv": ("region",),
+        "ReserveMargin.csv": ("region",),
+        "H2Price.csv": ("region",),
+    }
+
+    for filename, columns in electricity_checks.items():
+        df = pd.read_csv(cem_inputs / filename)
+        values = _unique_int_values(df, *columns)
+        assert metadata_ids == values, f"{filename} regions mismatch"
+
+
+def test_cap_regions_match_supply_regions() -> None:
+    cem_inputs = PROJECT_ROOT / "input" / "electricity" / "cem_inputs"
+    cap_map = pd.read_csv(cem_inputs / "CarbonCapGroupMap.csv")
+    supply_curve = pd.read_csv(cem_inputs / "SupplyCurve.csv")
+    supply_price = pd.read_csv(cem_inputs / "SupplyPrice.csv")
+
+    cap_ids = _unique_int_values(cap_map, "region")
+    supply_curve_ids = _unique_int_values(supply_curve, "region")
+    supply_price_ids = _unique_int_values(supply_price, "region")
+
+    assert cap_ids == supply_curve_ids == supply_price_ids


### PR DESCRIPTION
## Summary
- update the GUI region metadata so the WNCentral aggregate has its own identifier and aliases
- add data integrity tests to ensure region IDs match hydrogen and electricity inputs and cap/supply mappings
- extend dispatch tests to audit fuel-cost calculations and demand-driven scaling of generation and emissions

## Testing
- pytest tests/test_region_data_integrity.py tests/test_dispatch_lp_network.py

------
https://chatgpt.com/codex/tasks/task_e_68d7536832888327a0b3052a10578e31