### PR TITLE
Ensure GUI year ranges trigger full runs and expose CCR metadata

### DIFF
--- a/engine/run_loop.py
+++ b/engine/run_loop.py
@@ -1259,6 +1259,8 @@ def _build_engine_outputs(
         shortage_flag = bool(entry.get("shortage_any", False))
         finalized = bool(entry.get("finalized", False))
 
+        allowance_value = float(entry.get("allowance_price_last", price_value))
+
         annual_rows.append(
             {
                 "year": year,


### PR DESCRIPTION
## Summary
- ensure end-to-end outputs always carry an allowance price by normalising the engine aggregation
- propagate CCR trigger and quantity data to the allowance market module config while keeping cap region metadata intact
- add defensive UI messaging, slider-year coverage checks, and regression tests that exercise deep carbon pricing and CCR visibility

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7537704f08327bf03d77a5b6aaca4