### PR TITLE
Add comprehensive engine audit reporting

### DIFF
--- a/dispatch/interface.py
+++ b/dispatch/interface.py
@@ -25,6 +25,26 @@ class DispatchResult:
         Net energy transfers between regions measured in megawatt-hours. Keys
         are tuples ``(region_a, region_b)`` where positive values indicate a
         flow from ``region_a`` to ``region_b``.
+    emissions_by_fuel:
+        Mapping of fuel labels to their contribution to total emissions in tons.
+    capacity_mwh_by_fuel:
+        Available annual energy capability by fuel measured in megawatt-hours.
+    capacity_mw_by_fuel:
+        Available instantaneous capacity by fuel measured in megawatts.
+    generation_by_unit:
+        Dispatch by individual generating unit in megawatt-hours.
+    capacity_mwh_by_unit:
+        Available annual energy capability by unit in megawatt-hours.
+    capacity_mw_by_unit:
+        Available instantaneous capacity by unit in megawatts.
+    variable_cost_by_fuel:
+        Variable (fuel and operations) cost incurred by fuel in dollars.
+    allowance_cost_by_fuel:
+        Allowance compliance cost incurred by fuel in dollars.
+    carbon_price_cost_by_fuel:
+        Exogenous carbon price cost incurred by fuel in dollars.
+    total_cost_by_fuel:
+        Sum of variable and carbon-related costs by fuel in dollars.
     generation_by_region:
         Mapping of regions to total generation produced within the region.
     generation_by_coverage:
@@ -43,6 +63,16 @@ class DispatchResult:
     emissions_tons: float
     emissions_by_region: Dict[str, float] = field(default_factory=dict)
     flows: Dict[Tuple[str, str], float] = field(default_factory=dict)
+    emissions_by_fuel: Dict[str, float] = field(default_factory=dict)
+    capacity_mwh_by_fuel: Dict[str, float] = field(default_factory=dict)
+    capacity_mw_by_fuel: Dict[str, float] = field(default_factory=dict)
+    generation_by_unit: Dict[str, float] = field(default_factory=dict)
+    capacity_mwh_by_unit: Dict[str, float] = field(default_factory=dict)
+    capacity_mw_by_unit: Dict[str, float] = field(default_factory=dict)
+    variable_cost_by_fuel: Dict[str, float] = field(default_factory=dict)
+    allowance_cost_by_fuel: Dict[str, float] = field(default_factory=dict)
+    carbon_price_cost_by_fuel: Dict[str, float] = field(default_factory=dict)
+    total_cost_by_fuel: Dict[str, float] = field(default_factory=dict)
     generation_by_region: Dict[str, float] = field(default_factory=dict)
     generation_by_coverage: Dict[str, float] = field(default_factory=dict)
     imports_to_covered: float = 0.0

--- a/dispatch/stub.py
+++ b/dispatch/stub.py
@@ -57,12 +57,28 @@ def solve(
         fuel: output * demand_factor for fuel, output in _BASE_GEN_BY_FUEL.items()
     }
 
+    emissions_by_fuel: Dict[str, float] = {}
+    total_gen = sum(gen_by_fuel.values())
+    if total_gen > 0.0:
+        for fuel, output in gen_by_fuel.items():
+            emissions_by_fuel[fuel] = emissions * float(output) / float(total_gen)
+
     return DispatchResult(
         gen_by_fuel=gen_by_fuel,
         region_prices=dict(_REGION_PRICES),
         emissions_tons=emissions,
         emissions_by_region={'system': emissions},
         flows={},
+        emissions_by_fuel=emissions_by_fuel,
+        capacity_mwh_by_fuel={},
+        capacity_mw_by_fuel={},
+        generation_by_unit={},
+        capacity_mwh_by_unit={},
+        capacity_mw_by_unit={},
+        variable_cost_by_fuel={},
+        allowance_cost_by_fuel={},
+        carbon_price_cost_by_fuel={},
+        total_cost_by_fuel={},
     )
 
 

--- a/engine/audits.py
+++ b/engine/audits.py
@@ -1,0 +1,232 @@
+"""Post-run audit checks for engine outputs."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import math
+
+try:  # pragma: no cover - optional dependency guard
+    import pandas as pd
+except ImportError:  # pragma: no cover - optional dependency
+    pd = None  # type: ignore[assignment]
+
+DEFAULT_TOLERANCE = 1e-6
+
+
+def _ensure_pandas() -> None:
+    if pd is None:  # pragma: no cover - exercised indirectly
+        raise ImportError(
+            "pandas is required for engine audits; install it with `pip install pandas`."
+        )
+
+
+def _coerce_numeric_series(series: "pd.Series") -> "pd.Series":
+    numeric = pd.to_numeric(series, errors="coerce").fillna(0.0)
+    return numeric.astype(float)
+
+
+def _aggregate_by_year(df: "pd.DataFrame", value_column: str) -> "pd.Series":
+    if df.empty or value_column not in df.columns:
+        return pd.Series(dtype=float)
+    working = df.copy()
+    year_series = pd.to_numeric(working.get("year"), errors="coerce")
+    working = working.assign(year=year_series).dropna(subset=["year"])
+    if working.empty:
+        return pd.Series(dtype=float)
+    working["year"] = working["year"].astype(int)
+    working[value_column] = _coerce_numeric_series(working[value_column])
+    return working.groupby("year")[value_column].sum()
+
+
+def _max_abs_difference(a: "pd.Series", b: "pd.Series") -> float:
+    if a.empty and b.empty:
+        return 0.0
+    combined_index = sorted(set(a.index) | set(b.index))
+    aligned_a = a.reindex(combined_index, fill_value=0.0)
+    aligned_b = b.reindex(combined_index, fill_value=0.0)
+    if aligned_a.empty and aligned_b.empty:
+        return 0.0
+    return float((aligned_a - aligned_b).abs().max())
+
+
+def run_audits(
+    *,
+    annual_df: "pd.DataFrame",
+    emissions_by_region_df: "pd.DataFrame",
+    emissions_by_fuel_df: "pd.DataFrame",
+    generation_by_fuel_df: "pd.DataFrame",
+    capacity_by_fuel_df: "pd.DataFrame",
+    cost_by_fuel_df: "pd.DataFrame",
+    stranded_units_df: "pd.DataFrame",
+    demand_by_year: Mapping[int, float],
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> dict[str, Any]:
+    """Return a structured audit report for the supplied output tables."""
+
+    _ensure_pandas()
+
+    report: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Emissions reconciliation
+    # ------------------------------------------------------------------
+    emissions_total = _aggregate_by_year(annual_df, "emissions_tons")
+    regional_total = _aggregate_by_year(emissions_by_region_df, "emissions_tons")
+    fuel_total = _aggregate_by_year(emissions_by_fuel_df, "emissions_tons")
+
+    emissions_section: dict[str, Any] = {
+        "passed": True,
+        "max_region_gap": 0.0,
+        "max_fuel_gap": 0.0,
+        "issues": [],
+    }
+
+    if emissions_total.empty or regional_total.empty:
+        emissions_section["passed"] = False
+        emissions_section["issues"].append("emissions_data_missing")
+    else:
+        region_gap = _max_abs_difference(regional_total, emissions_total)
+        emissions_section["max_region_gap"] = region_gap
+        if region_gap > tolerance:
+            emissions_section["passed"] = False
+            emissions_section["issues"].append("regional_total_mismatch")
+
+    if fuel_total.empty:
+        emissions_section["passed"] = False
+        emissions_section["issues"].append("fuel_emissions_missing")
+    else:
+        fuel_gap = _max_abs_difference(fuel_total, regional_total)
+        emissions_section["max_fuel_gap"] = fuel_gap
+        if fuel_gap > tolerance:
+            emissions_section["passed"] = False
+            emissions_section["issues"].append("fuel_total_mismatch")
+
+    report["emissions"] = emissions_section
+
+    # ------------------------------------------------------------------
+    # Generation and capacity
+    # ------------------------------------------------------------------
+    generation_total = _aggregate_by_year(generation_by_fuel_df, "generation_mwh")
+    capacity_total = _aggregate_by_year(capacity_by_fuel_df, "capacity_mwh")
+    demand_series = pd.Series(
+        {int(year): float(value) for year, value in demand_by_year.items()}, dtype=float
+    ).sort_index()
+
+    generation_section: dict[str, Any] = {
+        "passed": True,
+        "generation_demand_gap": 0.0,
+        "capacity_margin": {},
+        "issues": [],
+        "stranded_units": [],
+    }
+
+    if generation_total.empty or demand_series.empty:
+        generation_section["passed"] = False
+        generation_section["issues"].append("generation_or_demand_missing")
+    else:
+        gen_gap = _max_abs_difference(generation_total, demand_series)
+        generation_section["generation_demand_gap"] = gen_gap
+        if gen_gap > tolerance:
+            generation_section["passed"] = False
+            generation_section["issues"].append("generation_does_not_meet_demand")
+
+    capacity_margin: dict[int, float] = {}
+    if not capacity_total.empty and not demand_series.empty:
+        combined_years = sorted(set(capacity_total.index) | set(demand_series.index))
+        for year in combined_years:
+            available = float(capacity_total.reindex([year], fill_value=0.0).iloc[0])
+            demand_value = float(demand_series.reindex([year], fill_value=0.0).iloc[0])
+            margin = available - demand_value
+            capacity_margin[int(year)] = margin
+            if margin < -tolerance:
+                generation_section["passed"] = False
+                generation_section["issues"].append("capacity_below_demand")
+    elif capacity_total.empty:
+        generation_section["issues"].append("capacity_data_missing")
+        generation_section["passed"] = False
+
+    generation_section["capacity_margin"] = capacity_margin
+
+    if not stranded_units_df.empty:
+        stranded_records = stranded_units_df.to_dict("records")
+        generation_section["stranded_units"] = stranded_records
+        if stranded_records:
+            generation_section.setdefault("issues", []).append("stranded_capacity_present")
+    else:
+        generation_section["stranded_units"] = []
+
+    report["generation_capacity"] = generation_section
+
+    # ------------------------------------------------------------------
+    # Cost reconciliation
+    # ------------------------------------------------------------------
+    cost_section: dict[str, Any] = {
+        "passed": True,
+        "max_system_gap": 0.0,
+        "max_allowance_gap": 0.0,
+        "issues": [],
+    }
+
+    if cost_by_fuel_df.empty:
+        cost_section["passed"] = False
+        cost_section["issues"].append("cost_data_missing")
+        report["cost"] = cost_section
+        return report
+
+    cost_totals = cost_by_fuel_df.groupby("year")[
+        ["variable_cost", "allowance_cost", "carbon_price_cost", "total_cost"]
+    ].sum()
+    system_gap_series = (
+        cost_totals["total_cost"]
+        - (
+            cost_totals["variable_cost"]
+            + cost_totals["allowance_cost"]
+            + cost_totals["carbon_price_cost"]
+        )
+    ).abs()
+    if not system_gap_series.empty:
+        max_system_gap = float(system_gap_series.max())
+        cost_section["max_system_gap"] = max_system_gap
+        if max_system_gap > tolerance:
+            cost_section["passed"] = False
+            cost_section["issues"].append("system_cost_mismatch")
+
+    allowance_series = pd.Series(dtype=float)
+    if {
+        "year",
+        "allowance_price",
+        "surrender",
+    }.issubset(annual_df.columns):
+        working = annual_df[["year", "allowance_price", "surrender"]].copy()
+        working["year"] = pd.to_numeric(working["year"], errors="coerce")
+        working = working.dropna(subset=["year"])
+        if not working.empty:
+            working["year"] = working["year"].astype(int)
+            working["allowance_price"] = _coerce_numeric_series(working["allowance_price"])
+            working["surrender"] = _coerce_numeric_series(working["surrender"])
+            allowance_series = (
+                working["allowance_price"] * working["surrender"]
+            ).groupby(working["year"]).sum()
+    else:
+        cost_section["issues"].append("allowance_revenue_missing")
+
+    if not allowance_series.empty:
+        allowance_cost_series = cost_totals["allowance_cost"].reindex(
+            allowance_series.index, fill_value=0.0
+        )
+        allowance_gap = (allowance_cost_series - allowance_series).abs()
+        if not allowance_gap.empty:
+            max_allowance_gap = float(allowance_gap.max())
+            cost_section["max_allowance_gap"] = max_allowance_gap
+            if max_allowance_gap > tolerance:
+                cost_section["passed"] = False
+                cost_section["issues"].append("allowance_revenue_mismatch")
+    else:
+        cost_section["passed"] = False
+
+    report["cost"] = cost_section
+
+    return report
+
+
+__all__ = ["run_audits"]

--- a/engine/outputs.py
+++ b/engine/outputs.py
@@ -35,6 +35,35 @@ class EngineOutputs:
     limiting_factors: list[str] = field(default_factory=list)
     emissions_total: Mapping[int, float] = field(default_factory=dict)
     emissions_by_region_map: Mapping[str, Mapping[int, float]] = field(default_factory=dict)
+    generation_by_fuel: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(columns=["year", "fuel", "generation_mwh"])
+    )
+    capacity_by_fuel: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(
+            columns=["year", "fuel", "capacity_mwh", "capacity_mw"]
+        )
+    )
+    cost_by_fuel: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(
+            columns=[
+                "year",
+                "fuel",
+                "variable_cost",
+                "allowance_cost",
+                "carbon_price_cost",
+                "total_cost",
+            ]
+        )
+    )
+    emissions_by_fuel: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(columns=["year", "fuel", "emissions_tons"])
+    )
+    stranded_units: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(
+            columns=["year", "unit", "capacity_mwh", "capacity_mw"]
+        )
+    )
+    audits: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         _ensure_pandas()
@@ -47,6 +76,11 @@ class EngineOutputs:
         emissions_filename: str = 'emissions_by_region.csv',
         price_filename: str = 'price_by_region.csv',
         flows_filename: str = 'flows.csv',
+        generation_filename: str = 'generation_by_fuel.csv',
+        capacity_filename: str = 'capacity_by_fuel.csv',
+        cost_filename: str = 'cost_by_fuel.csv',
+        emissions_fuel_filename: str = 'emissions_by_fuel.csv',
+        stranded_filename: str = 'stranded_units.csv',
     ) -> None:
         """Persist the stored DataFrames to ``outdir`` as CSV files."""
 
@@ -59,6 +93,18 @@ class EngineOutputs:
         self.emissions_by_region.to_csv(output_dir / emissions_filename, index=False)
         self.price_by_region.to_csv(output_dir / price_filename, index=False)
         self.flows.to_csv(output_dir / flows_filename, index=False)
+        if not self.generation_by_fuel.empty:
+            self.generation_by_fuel.to_csv(output_dir / generation_filename, index=False)
+        if not self.capacity_by_fuel.empty:
+            self.capacity_by_fuel.to_csv(output_dir / capacity_filename, index=False)
+        if not self.cost_by_fuel.empty:
+            self.cost_by_fuel.to_csv(output_dir / cost_filename, index=False)
+        if not self.emissions_by_fuel.empty:
+            self.emissions_by_fuel.to_csv(
+                output_dir / emissions_fuel_filename, index=False
+            )
+        if not self.stranded_units.empty:
+            self.stranded_units.to_csv(output_dir / stranded_filename, index=False)
 
     def emissions_summary_table(self) -> "pd.DataFrame":
         """Return a normalised emissions-by-region table for reporting."""


### PR DESCRIPTION
## Summary
- capture per-fuel emissions, capacity, and cost data from dispatch results
- add audit generation for engine outputs and expose new audit tables
- extend engine end-to-end tests to verify audit reconciliations

## Testing
- pytest tests/test_engine_end_to_end.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7537001388327aa4ba99d12a55768